### PR TITLE
Switch to JVM_OPTS, from _JAVA_OPTIONS

### DIFF
--- a/play-java-dagger2-example/scripts/script-helper
+++ b/play-java-dagger2-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-java-fileupload-example/scripts/script-helper
+++ b/play-java-fileupload-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-java-forms-example/scripts/script-helper
+++ b/play-java-forms-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-java-hello-world-tutorial/scripts/script-helper
+++ b/play-java-hello-world-tutorial/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-java-rest-api-example/scripts/script-helper
+++ b/play-java-rest-api-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-java-streaming-example/scripts/script-helper
+++ b/play-java-streaming-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-scala-hello-world-tutorial/scripts/script-helper
+++ b/play-scala-hello-world-tutorial/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi

--- a/play-scala-log4j2-example/scripts/script-helper
+++ b/play-scala-log4j2-example/scripts/script-helper
@@ -9,5 +9,5 @@ if [[ $java_version = 1.8* ]] ; then
     echo "The build is using Java 8 ($java_version). No addional JVM params needed."
 else
     echo "The build is using Java 9+ ($java_version). We need additional JVM parameters"
-    export _JAVA_OPTIONS="$_JAVA_OPTIONS --add-modules=java.xml.bind"
+    export JVM_OPTS="$JVM_OPTS --add-modules=java.xml.bind"
 fi


### PR DESCRIPTION
I think that by switching some of the builds from "language: java" to
"language: scala" they're running with modern sbt-extras, which no
longer supports _JAVA_OPTIONS.