### PR TITLE
Build with Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-scala: 2.12.8
+scala: 2.13.0
 script: eval "$SCRIPT"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-scala: 2.13.0
+
 script: eval "$SCRIPT"
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-
+scala: 2.13.0
 script: eval "$SCRIPT"
 
 env:

--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -2,7 +2,7 @@ name := """play-java-chatroom-example"""
 
 version := "2.7.x"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 

--- a/play-java-compile-di-example/build.sbt
+++ b/play-java-compile-di-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 ThisBuild / scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 ThisBuild / javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation")

--- a/play-java-dagger2-example/app/views/index.scala.html
+++ b/play-java-dagger2-example/app/views/index.scala.html
@@ -9,7 +9,7 @@
 
     @helper.form(action = routes.TimeController.indexPost()) {
 
-        @helper.select(field = form("timeZone"), options = helper.options(timeZones))
+        @helper.select(field = form("timeZone"), options = helper.options(timeZones).toSeq)
         <input type="submit" value="submit"/>
     }
 

--- a/play-java-dagger2-example/build.sbt
+++ b/play-java-dagger2-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += ws
 

--- a/play-java-ebean-example/build.sbt
+++ b/play-java-ebean-example/build.sbt
@@ -2,7 +2,7 @@ name := "play-java-ebean-example"
 
 version := "1.0.0-SNAPSHOT"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava, PlayEbean)
 

--- a/play-java-fileupload-example/build.sbt
+++ b/play-java-fileupload-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 

--- a/play-java-forms-example/build.sbt
+++ b/play-java-forms-example/build.sbt
@@ -4,7 +4,7 @@ version := "2.7.x"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 

--- a/play-java-grpc-example/build.sbt
+++ b/play-java-grpc-example/build.sbt
@@ -43,7 +43,7 @@ lazy val `play-java-grpc-example` = (project in file("."))
     packageName in Docker := "play-java-grpc-example",
   )
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation")
 

--- a/play-java-grpc-example/build.sbt
+++ b/play-java-grpc-example/build.sbt
@@ -43,7 +43,7 @@ lazy val `play-java-grpc-example` = (project in file("."))
     packageName in Docker := "play-java-grpc-example",
   )
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.8"
 scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation")
 

--- a/play-java-grpc-example/docs/build.sbt
+++ b/play-java-grpc-example/docs/build.sbt
@@ -1,4 +1,4 @@
 paradoxTheme := Some(builtinParadoxTheme("generic"))
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 

--- a/play-java-grpc-example/scripts/test-sbt
+++ b/play-java-grpc-example/scripts/test-sbt
@@ -3,4 +3,4 @@
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |" 
 echo "+----------------------------+"
-./ssl-play ++$TRAVIS_SCALA_VERSION test docs/paradox
+./ssl-play ++2.12.8 test docs/paradox

--- a/play-java-hello-world-tutorial/build.sbt
+++ b/play-java-hello-world-tutorial/build.sbt
@@ -5,6 +5,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice

--- a/play-java-jpa-example/build.sbt
+++ b/play-java-jpa-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += javaJpa

--- a/play-java-rest-api-example/build.sbt
+++ b/play-java-rest-api-example/build.sbt
@@ -11,7 +11,7 @@ inThisBuild(
       "com.google.code.findbugs" % "jsr305" % "3.0.1",
       "com.google.guava" % "guava" % "22.0"
     ),
-    scalaVersion := "2.12.8"
+    scalaVersion := "2.13.0"
   )
 )
 

--- a/play-java-rest-api-example/build.sbt
+++ b/play-java-rest-api-example/build.sbt
@@ -11,7 +11,7 @@ inThisBuild(
       "com.google.code.findbugs" % "jsr305" % "3.0.1",
       "com.google.guava" % "guava" % "22.0"
     ),
-    scalaVersion := "2.13.0"
+    scalaVersion := "2.12.8"
   )
 )
 

--- a/play-java-rest-api-example/scripts/test-sbt
+++ b/play-java-rest-api-example/scripts/test-sbt
@@ -3,4 +3,4 @@
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |" 
 echo "+----------------------------+"
-sbt ++$TRAVIS_SCALA_VERSION test
+sbt ++2.12.8 test

--- a/play-java-starter-example/build.sbt
+++ b/play-java-starter-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 javacOptions ++= Seq(
   "-encoding", "UTF-8",

--- a/play-java-streaming-example/build.sbt
+++ b/play-java-streaming-example/build.sbt
@@ -2,7 +2,7 @@ name := "play-java-streaming-example"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -2,7 +2,7 @@ name := "play-java-websocket-example"
 
 version := "1.0"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 // https://github.com/sbt/junit-interface
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v")

--- a/play-scala-chatroom-example/README.md
+++ b/play-scala-chatroom-example/README.md
@@ -26,7 +26,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents) e
     // recoverWithRetries -1 is essentially "recoverWith"
     val source = MergeHub.source[WSMessage]
       .log("source")
-      .recoverWithRetries(-1, { case _: Exception ⇒ Source.empty })
+      .recoverWithRetries(-1, { case _: Exception => Source.empty })
 
     val sink = BroadcastHub.sink[WSMessage]
     source.toMat(sink)(Keep.both).run()

--- a/play-scala-chatroom-example/app/controllers/HomeController.scala
+++ b/play-scala-chatroom-example/app/controllers/HomeController.scala
@@ -37,7 +37,7 @@ class HomeController @Inject()(val controllerComponents: ControllerComponents, i
       .log("source")
       // Let's also do some input sanitization to avoid XSS attacks
       .map(inputSanitizer.sanitize)
-      .recoverWithRetries(-1, { case _: Exception ⇒ Source.empty })
+      .recoverWithRetries(-1, { case _: Exception => Source.empty })
 
     val sink = BroadcastHub.sink[WSMessage]
     source.toMat(sink)(Keep.both).run()

--- a/play-scala-chatroom-example/build.sbt
+++ b/play-scala-chatroom-example/build.sbt
@@ -6,7 +6,7 @@ name := """play-chatroom-scala-example"""
 
 version := "2.7.x"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 

--- a/play-scala-compile-di-example/build.sbt
+++ b/play-scala-compile-di-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 ThisBuild / javacOptions ++= List(
   "-Xlint:unchecked",

--- a/play-scala-fileupload-example/build.sbt
+++ b/play-scala-fileupload-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += ws
 libraryDependencies += guice

--- a/play-scala-forms-example/build.sbt
+++ b/play-scala-forms-example/build.sbt
@@ -2,7 +2,7 @@ name := """play-scala-forms-example"""
 
 version := "2.7.x"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 

--- a/play-scala-grpc-example/build.sbt
+++ b/play-scala-grpc-example/build.sbt
@@ -43,7 +43,7 @@ lazy val `play-scala-grpc-example` = (project in file("."))
       packageName in Docker := "play-scala-grpc-example",
     )
 
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.8"
 scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 
 libraryDependencies += guice

--- a/play-scala-grpc-example/build.sbt
+++ b/play-scala-grpc-example/build.sbt
@@ -43,7 +43,7 @@ lazy val `play-scala-grpc-example` = (project in file("."))
       packageName in Docker := "play-scala-grpc-example",
     )
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 
 libraryDependencies += guice

--- a/play-scala-grpc-example/docs/build.sbt
+++ b/play-scala-grpc-example/docs/build.sbt
@@ -1,4 +1,4 @@
 paradoxTheme := Some(builtinParadoxTheme("generic"))
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 

--- a/play-scala-grpc-example/scripts/test-sbt
+++ b/play-scala-grpc-example/scripts/test-sbt
@@ -3,4 +3,4 @@
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |" 
 echo "+----------------------------+"
-./ssl-play ++$TRAVIS_SCALA_VERSION test docs/paradox
+./ssl-play ++2.12.8 test docs/paradox

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -5,8 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
-
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test

--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -2,7 +2,7 @@ name := """play-isolated-slick"""
 
 version := "1.1-SNAPSHOT"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val flyway = (project in file("modules/flyway"))
   .enablePlugins(FlywayPlugin)

--- a/play-scala-isolated-slick-example/modules/slick/build.sbt
+++ b/play-scala-isolated-slick-example/modules/slick/build.sbt
@@ -5,7 +5,7 @@ libraryDependencies ++= Seq(
   "com.zaxxer" % "HikariCP" % "3.3.1",
   "com.typesafe.slick" %% "slick" % "3.3.2",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.3.2",
-  "com.github.tototoshi" %% "slick-joda-mapper" % "2.3.0"
+  "com.github.tototoshi" %% "slick-joda-mapper" % "2.4.1"
 )
 
 lazy val databaseUrl = sys.env.getOrElse("DB_DEFAULT_URL", "jdbc:h2:./test")

--- a/play-scala-isolated-slick-example/project/Build.scala
+++ b/play-scala-isolated-slick-example/project/Build.scala
@@ -12,7 +12,6 @@ object Common {
       "-feature",
       "-unchecked",
       "-Xlint",
-      "-Yno-adapted-args",
       "-Ywarn-numeric-widen"
     ),
     resolvers ++= Seq(

--- a/play-scala-isolated-slick-example/project/Build.scala
+++ b/play-scala-isolated-slick-example/project/Build.scala
@@ -4,7 +4,7 @@ import sbt.{Resolver, _}
 object Common {
 
   def projectSettings = Seq(
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.0",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions ++= Seq(
       "-encoding", "UTF-8", // yes, this is 2 args

--- a/play-scala-isolated-slick-example/project/plugins.sbt
+++ b/play-scala-isolated-slick-example/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("org.flywaydb" % "flyway-sbt" % "4.2.0")
 
 // Slick code generation
 // https://github.com/tototoshi/sbt-slick-codegen
-addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.3.0")
+addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.4.0")
 
 libraryDependencies += "com.h2database" % "h2" % "1.4.196"
 

--- a/play-scala-isolated-slick-example/project/plugins.sbt
+++ b/play-scala-isolated-slick-example/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("org.flywaydb" % "flyway-sbt" % "4.2.0")
 
 // Slick code generation
 // https://github.com/tototoshi/sbt-slick-codegen
-addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.4.0")
+addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.3.0")
 
 libraryDependencies += "com.h2database" % "h2" % "1.4.196"
 

--- a/play-scala-log4j2-example/build.sbt
+++ b/play-scala-log4j2-example/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .disablePlugins(PlayLogback)
 
-scalaVersion in ThisBuild := "2.12.8"
+scalaVersion in ThisBuild := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.1"

--- a/play-scala-macwire-di-example/build.sbt
+++ b/play-scala-macwire-di-example/build.sbt
@@ -4,7 +4,7 @@ version := "2.7.x"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
 libraryDependencies += "com.softwaremill.macwire" %% "macros" % "2.3.2" % "provided"

--- a/play-scala-rest-api-example/app/v1/post/PostRouter.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostRouter.scala
@@ -13,7 +13,8 @@ class PostRouter @Inject()(controller: PostController) extends SimpleRouter {
   val prefix = "/v1/posts"
 
   def link(id: PostId): String = {
-    import com.netaporter.uri.dsl._
+    
+    import io.lemonlabs.uri.dsl._
     val url = prefix / id.toString
     url.toString()
   }

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 lazy val GatlingTest = config("gatling") extend Test
 
-scalaVersion in ThisBuild := "2.12.8"
+scalaVersion in ThisBuild := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += "org.joda" % "joda-convert" % "2.1.2"

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 lazy val GatlingTest = config("gatling") extend Test
 
-scalaVersion in ThisBuild := "2.13.0"
+scalaVersion in ThisBuild := "2.12.8"
 
 libraryDependencies += guice
 libraryDependencies += "org.joda" % "joda-convert" % "2.1.2"

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -9,8 +9,8 @@ libraryDependencies += guice
 libraryDependencies += "org.joda" % "joda-convert" % "2.1.2"
 libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "5.2"
 
-libraryDependencies += "com.netaporter" %% "scala-uri" % "0.4.16"
-libraryDependencies += "net.codingwell" %% "scala-guice" % "4.2.1"
+libraryDependencies += "io.lemonlabs" %% "scala-uri" % "1.4.8" 
+libraryDependencies += "net.codingwell" %% "scala-guice" % "4.2.5"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
 libraryDependencies += "io.gatling.highcharts" % "gatling-charts-highcharts" % "3.0.1.1" % Test

--- a/play-scala-rest-api-example/scripts/test-sbt
+++ b/play-scala-rest-api-example/scripts/test-sbt
@@ -6,4 +6,4 @@ set -o pipefail
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |"
 echo "+----------------------------+"
-sbt ++$TRAVIS_SCALA_VERSION test
+sbt ++2.12.8 test

--- a/play-scala-secure-session-example/build.sbt
+++ b/play-scala-secure-session-example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += ws
 libraryDependencies += guice

--- a/play-scala-slick-example/build.sbt
+++ b/play-scala-slick-example/build.sbt
@@ -4,7 +4,7 @@ version := "2.7.x"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += "com.typesafe.play" %% "play-slick" % "4.0.2"

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test

--- a/play-scala-streaming-example/build.sbt
+++ b/play-scala-streaming-example/build.sbt
@@ -2,7 +2,7 @@ name := "play-scala-streaming-example"
 
 version := "2.7.x"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
   .aggregate(one, two)
   .dependsOn(one, two)
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += ws
 libraryDependencies += guice

--- a/play-scala-tls-example/modules/one/build.sbt
+++ b/play-scala-tls-example/modules/one/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"

--- a/play-scala-tls-example/modules/two/build.sbt
+++ b/play-scala-tls-example/modules/two/build.sbt
@@ -1,1 +1,1 @@
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"

--- a/play-scala-websocket-example/build.sbt
+++ b/play-scala-websocket-example/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 val akkaVersion = "2.5.23"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 libraryDependencies += guice
 libraryDependencies += ws


### PR DESCRIPTION
A few projects are broken because of missing dependencies:


* play-java-grpc-example

```
com.lightbend.akka.grpc#akka-grpc-runtime_2.13;0.6.2: not found
com.lightbend.play#play-grpc-testkit_2.13;0.7.0: not found
```

* play-scala-grpc-example

```
[warn] 	:: com.thesamet.scalapb#scalapb-runtime_2.13;0.8.4: not found
[warn] 	:: com.lightbend.akka.grpc#akka-grpc-runtime_2.13;0.6.2: not found
[warn] 	:: com.lightbend.play#play-grpc-scalatest_2.13;0.7.0: not found
[warn] 	:: com.lightbend.play#play-grpc-specs2_2.13;0.7.0: not found
```

* play-scala-rest-api-example

```
[warn] 	:: com.netaporter#scala-uri_2.13;0.4.16: not found
  // scala-uri also needs
  [warn] 	:: org.parboiled#parboiled_2.13;2.1.5: not found
  [warn] 	:: io.spray#spray-json_2.13;1.3.4: not found
[warn] 	:: net.codingwell#scala-guice_2.13;4.2.1: not found
  send PR https://github.com/codingwell/scala-guice/pull/81
```


* play-scala-isolated-slick-example

```
// they updated the repo, but no release so far. I pinged them
[warn] 	:: com.github.tototoshi#slick-joda-mapper_2.13;2.3.0: not found  
```

* play-java-rest-api-example

This is due to Gatling (Java lib) using some Scala 2.12 lib underneath
```
[error] java.lang.RuntimeException: Conflicting cross-version suffixes in: com.typesafe.akka:akka-actor, org.scala-lang.modules:scala-xml, org.scala-lang.modules:scala-java8-compat, org.scala-lang.modules:scala-parser-combinators, com.typesafe.akka:akka-slf4j
```

* play-java-dagger2-exmaple

I think this is a regression either in Play 2.7.3 or Twirl 4.0.2.(see https://github.com/playframework/play-samples/blob/2.7.x/play-java-dagger2-example/app/views/index.scala.html#L2) 

The `timeZones` should is a `java.util.List[String]`. I think this is expected since it's a java app. Users in the controller, call the template and pass a java collection. However, the `helper.options` is expecting a Scala collection.

```
[error] /home/travis/build/playframework/play-samples/play-java-dagger2-example/app/views/index.scala.html:12:67: overloaded method value apply with alternatives:
[error]   (options: List[String])List[(String, String)] <and>
[error]   (options: java.util.Map[String,String])Seq[(String, String)] <and>
[error]   (options: Map[String,String])Seq[(String, String)] <and>
[error]   (options: (String, String)*)Seq[(String, String)]
[error]  cannot be applied to (java.util.List[String])
[error]         @helper.select(field = form("timeZone"), options = helper.options(timeZones))
```
