### PR TITLE
Remove trailing slashes. Guide was misleading.

### DIFF
--- a/play-java-rest-api-example/app/views/index.scala.html
+++ b/play-java-rest-api-example/app/views/index.scala.html
@@ -20,7 +20,7 @@
 
 
 <pre>
-    <code>http GET localhost:9000/v1/posts/</code>
+    <code>http GET localhost:9000/v1/posts</code>
 </pre>
 
     <p>
@@ -28,11 +28,11 @@
     <p>
 
 <pre>
-    <code>http POST localhost:9000/v1/posts/ title="Some title" body="Some Body"</code>
+    <code>http POST localhost:9000/v1/posts title="Some title" body="Some Body"</code>
 </pre>
 
 <p>
-  You can always look at the API directly: <a href="/v1/posts/">/v1/posts</a>
+  You can always look at the API directly: <a href="/v1/posts">/v1/posts</a>
 </p>
 
   </body>


### PR DESCRIPTION
This is already correct on the scala counterpart.