### PR TITLE
Improves Java REST tests: unique Strings, negative assertions

### DIFF
--- a/play-java-rest-api-example/scripts/test-sbt
+++ b/play-java-rest-api-example/scripts/test-sbt
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -o pipefail
+
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |" 
 echo "+----------------------------+"

--- a/play-java-rest-api-example/test/it/IntegrationTest.java
+++ b/play-java-rest-api-example/test/it/IntegrationTest.java
@@ -1,6 +1,7 @@
 package it;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Ignore;
 import org.junit.Test;
 import play.Application;
 import play.inject.guice.GuiceApplicationBuilder;
@@ -12,9 +13,15 @@ import v1.post.PostData;
 import v1.post.PostRepository;
 import v1.post.PostResource;
 
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static play.test.Helpers.*;
 
 public class IntegrationTest extends WithApplication {
@@ -27,21 +34,52 @@ public class IntegrationTest extends WithApplication {
     @Test
     public void testList() {
         PostRepository repository = app.injector().instanceOf(PostRepository.class);
-        repository.create(new PostData("title", "body"));
+        repository.create(new PostData("title-of-post-123", "body-123"));
 
         Http.RequestBuilder request = new Http.RequestBuilder()
                 .method(GET)
                 .uri("/v1/posts");
 
         Result result = route(app, request);
-        final String body = contentAsString(result);
-        assertThat(body, containsString("body"));
+
+        assertJsonPayloadHasTitle("title-of-post-123", result) ;
+    }
+
+    @Test
+    public void testListWithTrailingSlash() {
+        PostRepository repository = app.injector().instanceOf(PostRepository.class);
+        repository.create(new PostData("title-of-another-post", "body-456"));
+
+        Http.RequestBuilder request = new Http.RequestBuilder()
+                .method(GET)
+                .uri("/v1/posts/");
+
+        Result result = route(app, request);
+        assertJsonPayloadHasTitle("title-of-another-post", result) ;
+    }
+
+    private void assertJsonPayloadHasTitle(String expectedTitle, Result actual){
+        final String responseBody = contentAsString(actual);
+        assertFalse(responseBody.contains("Action Not Found"));
+        JsonNode listOfPosts = Json.parse(responseBody);
+        Iterator<JsonNode> elements = listOfPosts.elements();
+        // spliterator dance to build a Stream from an Iterator
+        Optional<PostResource> post = StreamSupport.stream(
+            Spliterators.spliteratorUnknownSize(
+                elements,
+                Spliterator.ORDERED),
+            false)
+            .map(jsonNode -> Json.fromJson(jsonNode, PostResource.class))
+            .filter(p -> p.getTitle().equals(expectedTitle))
+            .findFirst();
+
+        assertTrue(post.isPresent());
     }
 
     @Test
     public void testTimeoutOnUpdate() {
         PostRepository repository = app.injector().instanceOf(PostRepository.class);
-        repository.create(new PostData("title", "body"));
+        repository.create(new PostData("title-testTimeoutOnUpdate", "body-testTimeoutOnUpdate"));
 
         JsonNode json = Json.toJson(new PostResource("1", "http://localhost:9000/v1/posts/1", "some title", "somebody"));
 
@@ -57,7 +95,7 @@ public class IntegrationTest extends WithApplication {
     @Test
     public void testCircuitBreakerOnShow() {
         PostRepository repository = app.injector().instanceOf(PostRepository.class);
-        repository.create(new PostData("title", "body"));
+        repository.create(new PostData("title-testTimeoutOnUpdate", "body-testCircuitBreakerOnShow"));
 
         Http.RequestBuilder request = new Http.RequestBuilder()
                 .method(GET)

--- a/play-java-rest-api-example/test/it/IntegrationTest.java
+++ b/play-java-rest-api-example/test/it/IntegrationTest.java
@@ -95,7 +95,7 @@ public class IntegrationTest extends WithApplication {
     @Test
     public void testCircuitBreakerOnShow() {
         PostRepository repository = app.injector().instanceOf(PostRepository.class);
-        repository.create(new PostData("title-testTimeoutOnUpdate", "body-testCircuitBreakerOnShow"));
+        repository.create(new PostData("title-testCircuitBreakerOnShow", "body-testCircuitBreakerOnShow"));
 
         Http.RequestBuilder request = new Http.RequestBuilder()
                 .method(GET)


### PR DESCRIPTION
This PR introduces multiple changes:

1. each test case uses a unique `title` and `body` on the data it creates. This is necessary because this is a stateful tests and assertions were being mixed up
2. assertions are more strict. Previous implementation would treat the response as a plain `String` and assert that contained the `body` substring. This assertion is wrong since the Play failure page (an HTML indicating the requested URI is missing) can be converted to a `String` and it also contains the substring `body`. 
3. Adds a test case to ensure `GET /v1/posts/` works. Equivalent to #48 but for the java sample.


This PR is currently not passing all the tests (tested in `2.8.0-M3` and `2.7.3`). The reason is a test expecting `GET /v1/posts/` (the requests includes a trailing slash) fails.



This is related to https://github.com/playframework/playframework/issues/8850, #47 and #48 