### PR TITLE
fix warning 'warning: value H2Driver in package driver is deprecated (since 3.2)

### DIFF
--- a/play-scala-isolated-slick-example/modules/slick/build.sbt
+++ b/play-scala-isolated-slick-example/modules/slick/build.sbt
@@ -16,7 +16,7 @@ slickCodegenSettings
 slickCodegenDatabaseUrl := databaseUrl
 slickCodegenDatabaseUser := databaseUser
 slickCodegenDatabasePassword := databasePassword
-slickCodegenDriver := slick.driver.H2Driver
+slickCodegenDriver := slick.jdbc.H2Profile
 slickCodegenJdbcDriver := "org.h2.Driver"
 slickCodegenOutputPackage := "com.example.user.slick"
 slickCodegenExcludedTables := Seq("schema_version")


### PR DESCRIPTION
… Use object `slick.jdbc.H2Profile` instead of `slick.driver.H2Driver`'

Project (still) compiles, tests succeed and sample application runs.