### PR TITLE
 Fix branch protection rules

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,13 +25,16 @@ teams:
 branches:
   - name: "[0-9].*.x"
     protection:
-      # We don't require reviews for sample applications because they are mainly
-      # updated by template-control, which is an automated process
-      required_pull_request_reviews: null
-      # Required. Require status checks to pass before merging. Set to null to disable
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: true
+      # Require status checks to pass before merging
       required_status_checks:
-        # Required. The list of status checks to require in order to merge into this branch
+        # The list of status checks to require in order to merge into this branch
         contexts: ["Travis CI - Pull Request", "typesafe-cla-validator"]
+      # all settins in branches.protection must be set, if not used we must set to null  
+      restrictions: null
+      enforce_admins: null
 
 # Labels: tailored list of labels to be used by sample applications
 labels:


### PR DESCRIPTION
This fix the issue of missing settings https://github.com/probot/settings/issues/150, but also protect the branch. 

We were not using branch protection because we were updating it from templatecontrol. That's not the case anymore.