### PR TITLE
Remove unused netty settings

### DIFF
--- a/play-java-starter-example/conf/application.conf
+++ b/play-java-starter-example/conf/application.conf
@@ -146,18 +146,6 @@ play.http {
   }
 }
 
-## Netty Provider
-# https://www.playframework.com/documentation/latest/SettingsNetty
-# ~~~~~
-play.server.netty {
-  # Whether the Netty wire should be logged
-  #log.wire = true
-
-  # If you run Play on Linux, you can use Netty's native socket transport
-  # for higher performance with less garbage.
-  #transport = "native"
-}
-
 ## WS (HTTP Client)
 # https://www.playframework.com/documentation/latest/ScalaWS#Configuring-WS
 # ~~~~~

--- a/play-scala-log4j2-example/conf/application.conf
+++ b/play-scala-log4j2-example/conf/application.conf
@@ -148,18 +148,6 @@ play.http {
   }
 }
 
-## Netty Provider
-# https://www.playframework.com/documentation/latest/SettingsNetty
-# ~~~~~
-play.server.netty {
-  # Whether the Netty wire should be logged
-  #log.wire = true
-
-  # If you run Play on Linux, you can use Netty's native socket transport
-  # for higher performance with less garbage.
-  #transport = "native"
-}
-
 ## WS (HTTP Client)
 # https://www.playframework.com/documentation/latest/ScalaWS#Configuring-WS
 # ~~~~~

--- a/play-scala-starter-example/conf/application.conf
+++ b/play-scala-starter-example/conf/application.conf
@@ -146,18 +146,6 @@ play.http {
   }
 }
 
-## Netty Provider
-# https://www.playframework.com/documentation/latest/SettingsNetty
-# ~~~~~
-play.server.netty {
-  # Whether the Netty wire should be logged
-  #log.wire = true
-
-  # If you run Play on Linux, you can use Netty's native socket transport
-  # for higher performance with less garbage.
-  #transport = "native"
-}
-
 ## WS (HTTP Client)
 # https://www.playframework.com/documentation/latest/ScalaWS#Configuring-WS
 # ~~~~~


### PR DESCRIPTION
Even though #44 states we should replace these settings with Akka HTTP values, I think removing the Netty ones (Currently unused on those samples) is enough.

Fixes #44 