### PR TITLE
fix command to check sbt version

### DIFF
--- a/play-scala-hello-world-tutorial/README.md
+++ b/play-scala-hello-world-tutorial/README.md
@@ -14,7 +14,7 @@ java -version
 To check your sbt version, enter the following in a command window:
 
 ```bash
-sbt sbt-version
+sbt sbtVersion
 ```
 
 If you do not have the required versions, follow these links to obtain them:


### PR DESCRIPTION
Now, command to check sbt version is "sbt sbtVersion"
I fixed play-scala-hello-world-tutorial/README.md.