### PR TITLE
travis: Use latest JDK & store Coursier's cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,11 @@ env:
 before_install:
   - sudo add-apt-repository -y ppa:ondrej/php && sudo apt-get -qq update && sudo apt-get install -y libsodium-dev # for secure session examples
   - curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
-install: jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
+install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 cache:
   directories:
+    - "$HOME/.cache/coursier"
     - "$HOME/.ivy2/cache"
     - "$HOME/.jabba/jdk"
     - "$HOME/.sbt"

--- a/play-java-chatroom-example/project/plugins.sbt
+++ b/play-java-chatroom-example/project/plugins.sbt
@@ -1,3 +1,3 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 

--- a/play-java-compile-di-example/project/plugins.sbt
+++ b/play-java-compile-di-example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-dagger2-example/project/plugins.sbt
+++ b/play-java-dagger2-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-ebean-example/project/plugins.sbt
+++ b/play-java-ebean-example/project/plugins.sbt
@@ -1,4 +1,4 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-play-ebean" % "5.0.2")

--- a/play-java-fileupload-example/project/plugins.sbt
+++ b/play-java-fileupload-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-forms-example/project/plugins.sbt
+++ b/play-java-forms-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-grpc-example/build.sbt
+++ b/play-java-grpc-example/build.sbt
@@ -1,3 +1,4 @@
+import play.core.PlayVersion.akkaVersion
 import play.grpc.gen.javadsl.{ PlayJavaClientCodeGenerator, PlayJavaServerCodeGenerator }
 import com.typesafe.sbt.packager.docker.{ Cmd, CmdLike, DockerAlias, ExecCmd }
 import play.java.grpc.sample.BuildInfo
@@ -55,7 +56,7 @@ val CompileDeps = Seq(
   guice,
   javaWs,
   "com.lightbend.play"      %% "play-grpc-runtime"   % BuildInfo.playGrpcVersion, 
-  "com.typesafe.akka"       %% "akka-discovery"      % "2.6.1", 
+  "com.typesafe.akka"       %% "akka-discovery"      % akkaVersion,
   "com.typesafe.akka"       %% "akka-http"           % "10.1.11",
   // Test Database
   "com.h2database" % "h2" % "1.4.199"

--- a/play-java-grpc-example/project/plugins.sbt
+++ b/play-java-grpc-example/project/plugins.sbt
@@ -3,7 +3,7 @@ val playGrpcV = "0.8.1"
 buildInfoKeys := Seq[BuildInfoKey]("playGrpcVersion" -> playGrpcV)
 buildInfoPackage := "play.java.grpc.sample"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 // #grpc_sbt_plugin
 // project/plugins.sbt

--- a/play-java-hello-world-tutorial/project/plugins.sbt
+++ b/play-java-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-jpa-example/project/plugins.sbt
+++ b/play-java-jpa-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")

--- a/play-java-rest-api-example/project/plugins.sbt
+++ b/play-java-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 // Load testing tool:
 // http://gatling.io/docs/2.2.2/extensions/sbt_plugin.html

--- a/play-java-starter-example/project/plugins.sbt
+++ b/play-java-starter-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-streaming-example/project/plugins.sbt
+++ b/play-java-streaming-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-java-telemetry-example/project/plugins.sbt
+++ b/play-java-telemetry-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.12.4")
 

--- a/play-java-websocket-example/project/plugins.sbt
+++ b/play-java-websocket-example/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 

--- a/play-scala-anorm-example/project/plugins.sbt
+++ b/play-scala-anorm-example/project/plugins.sbt
@@ -1,3 +1,3 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 

--- a/play-scala-chatroom-example/project/plugins.sbt
+++ b/play-scala-chatroom-example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-compile-di-example/project/plugins.sbt
+++ b/play-scala-compile-di-example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-fileupload-example/project/plugins.sbt
+++ b/play-scala-fileupload-example/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.typesafeRepo("snapshots")
 resolvers += Resolver.jcenterRepo
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-forms-example/project/plugins.sbt
+++ b/play-scala-forms-example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-grpc-example/build.sbt
+++ b/play-scala-grpc-example/build.sbt
@@ -1,3 +1,4 @@
+import play.core.PlayVersion.akkaVersion
 import play.grpc.gen.scaladsl.{ PlayScalaClientCodeGenerator, PlayScalaServerCodeGenerator }
 import com.typesafe.sbt.packager.docker.{ Cmd, CmdLike, DockerAlias, ExecCmd }
 import play.scala.grpc.sample.BuildInfo
@@ -51,7 +52,7 @@ lazy val `play-scala-grpc-example` = (project in file("."))
 val CompileDeps = Seq(
   guice,
   "com.lightbend.play"      %% "play-grpc-runtime"   % BuildInfo.playGrpcVersion, 
-  "com.typesafe.akka"       %% "akka-discovery"      % "2.6.1", 
+  "com.typesafe.akka"       %% "akka-discovery"      % akkaVersion,
   "com.typesafe.akka"       %% "akka-http"           % "10.1.11",
   // Test Database
   "com.h2database" % "h2" % "1.4.199"

--- a/play-scala-grpc-example/project/plugins.sbt
+++ b/play-scala-grpc-example/project/plugins.sbt
@@ -4,7 +4,7 @@ buildInfoKeys := Seq[BuildInfoKey]("playGrpcVersion" -> playGrpcV)
 buildInfoPackage := "play.scala.grpc.sample"
 
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 // #grpc_sbt_plugin
 // project/plugins.sbt

--- a/play-scala-hello-world-tutorial/project/plugins.sbt
+++ b/play-scala-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-isolated-slick-example/project/plugins.sbt
+++ b/play-scala-isolated-slick-example/project/plugins.sbt
@@ -16,4 +16,4 @@ addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.4.0")
 libraryDependencies += "com.h2database" % "h2" % "1.4.196"
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-log4j2-example/project/plugins.sbt
+++ b/play-scala-log4j2-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-macwire-di-example/project/plugins.sbt
+++ b/play-scala-macwire-di-example/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-rest-api-example/project/plugins.sbt
+++ b/play-scala-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 // sbt-paradox, used for documentation
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.4")

--- a/play-scala-secure-session-example/project/plugins.sbt
+++ b/play-scala-secure-session-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-slick-example/project/plugins.sbt
+++ b/play-scala-slick-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-starter-example/project/plugins.sbt
+++ b/play-scala-starter-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-streaming-example/project/plugins.sbt
+++ b/play-scala-streaming-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-telemetry-example/project/plugins.sbt
+++ b/play-scala-telemetry-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.12.4")
 

--- a/play-scala-tls-example/project/plugins.sbt
+++ b/play-scala-tls-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")

--- a/play-scala-websocket-example/project/plugins.sbt
+++ b/play-scala-websocket-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 


### PR DESCRIPTION
I was just checking as it looked like the sbt launchers weren't being cached.  Turns out they were, but the Coursier's cache wasn't being saved.  Added that and updated the JDK installation too.

Builds on #88.