### PR TITLE
Bump Scala/ScalaTest dependencies

### DIFF
--- a/play-scala-streaming-example/app/views/scalacomet.scala.html
+++ b/play-scala-streaming-example/app/views/scalacomet.scala.html
@@ -15,6 +15,6 @@
             }
     </script>
 
-    <iframe id="comet" src="@routes.ScalaCometController.streamClock.unique"></iframe>
+    <iframe id="comet" src="@routes.ScalaCometController.streamClock().unique"></iframe>
 
 }

--- a/play-scala-streaming-example/build.sbt
+++ b/play-scala-streaming-example/build.sbt
@@ -3,11 +3,11 @@ lazy val root = (project in file("."))
   .settings(
     name := "play-scala-streaming-example",
     version := "2.8.x",
-    scalaVersion := "2.13.1",
+    scalaVersion := "2.13.3",
     libraryDependencies ++= Seq(
       guice,
       ws % Test,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
     ),
     scalacOptions ++= Seq(
       "-feature",

--- a/play-scala-streaming-example/test/controllers/EventSourceControllerSpec.scala
+++ b/play-scala-streaming-example/test/controllers/EventSourceControllerSpec.scala
@@ -22,7 +22,7 @@ class EventSourceControllerSpec extends PlaySpec
             result.header.status mustEqual(OK)
           }
         case None =>
-          fail
+          fail()
       }
     }
   }

--- a/play-scala-streaming-example/test/controllers/ScalaCommentControllerSpec.scala
+++ b/play-scala-streaming-example/test/controllers/ScalaCommentControllerSpec.scala
@@ -23,7 +23,7 @@ class ScalaCommentControllerSpec extends PlaySpec
             result.header.status mustEqual(OK)
           }
         case None =>
-          fail
+          fail()
       }
     }
   }


### PR DESCRIPTION
- Bump to Scala 2.13.3
  - Fix warnings reported by this change (auto-application will no
    longer be supported in Scala 3)