### PR TITLE
Fix docs for grpc-examples

### DIFF
--- a/play-java-grpc-example/docs/src/main/paradox/locally.md
+++ b/play-java-grpc-example/docs/src/main/paradox/locally.md
@@ -5,9 +5,7 @@ HTTP/2 so we want Play to use HTTP/2. On top of that, we will also enable HTTPS.
 setups are supported to run Play and only the following can be used at the moment:
 
 1. you may use `sbt runProd` to run Play locally in a forked JVM in PROD mode, or
-1. you may use `./ssl-play run` to run Play in DEV mode within `sbt`.
-
-`./ssl-play` is a wrapper script around `sbt` that sets up the ALPN agent (required for HTTP/2) on the JVM running `sbt`.  
+1. you may use `sbt run` to run Play in DEV mode within `sbt`.
 
 In both execution modes above, `sbt` will also generate the server and client sources based on the `app/protobuf/*.proto` 
 files. The code generation happens thanks to the Akka gRPC plugin being enabled. See 

--- a/play-scala-grpc-example/docs/src/main/paradox/locally.md
+++ b/play-scala-grpc-example/docs/src/main/paradox/locally.md
@@ -5,9 +5,7 @@ HTTP/2 so we want Play to use HTTP/2. On top of that, we will also enable HTTPS.
 setups are supported to run Play and only the following can be used at the moment:
 
 1. you may use `sbt runProd` to run Play locally in a forked JVM in PROD mode, or
-1. you may use `./ssl-play run` to run Play in DEV mode within `sbt`.
-
-`./ssl-play` is a wrapper script around `sbt` that sets up the ALPN agent (required for HTTP/2) on the JVM running `sbt`.  
+1. you may use `sbt run` to run Play in DEV mode within `sbt`.
 
 In both execution modes above, `sbt` will also generate the server and client sources based on the `app/protobuf/*.proto` 
 files. The code generation happens thanks to the Akka gRPC plugin being enabled. See 


### PR DESCRIPTION
The `ssl-play` script for those two projects got removed in #111.