### PR TITLE
Updating log4j to 2.17 in docs, for CVE-2021-45105

### DIFF
--- a/play-scala-log4j2-example/build.sbt
+++ b/play-scala-log4j2-example/build.sbt
@@ -1,4 +1,4 @@
-val log4jVersion = "2.15.0"
+val log4jVersion = "2.17.0"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)


### PR DESCRIPTION
Updated log4j version to 2.17.0 for [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105) - https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105