### PR TITLE
Update to new sbt syntax to resolve deprecation warnings in compilation

### DIFF
--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       "org.awaitility" % "awaitility" % "3.1.6" % Test
     ),
     // Needed to make JUnit report the tests being run
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
+    (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation"

--- a/play-java-dagger2-example/build.sbt
+++ b/play-java-dagger2-example/build.sbt
@@ -10,13 +10,13 @@ lazy val root = (project in file("."))
       "com.google.dagger" % "dagger-compiler" % "2.25.2"
     ),
     // move the java annotation code into generated directory
-    javacOptions in Compile := { (managedSourceDirectories in Compile).value.head.mkdirs(); javacOptions.value },
-    javacOptions in Compile ++= Seq("-s", (managedSourceDirectories in Compile).value.head.getAbsolutePath),
+    (Compile / javacOptions) := { (Compile / managedSourceDirectories).value.head.mkdirs(); javacOptions.value },
+    (Compile / javacOptions) ++= Seq("-s", (Compile / managedSourceDirectories).value.head.getAbsolutePath),
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",
       "-Werror"
     ),
     // Verbose tests
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+    (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
   )

--- a/play-java-ebean-example/build.sbt
+++ b/play-java-ebean-example/build.sbt
@@ -16,6 +16,6 @@ lazy val root = (project in file("."))
       "javax.activation" % "activation" % "1.1.1",
       "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.2",
     ),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    (Test / testOptions) += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-Werror")
   )

--- a/play-java-forms-example/build.sbt
+++ b/play-java-forms-example/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
 scalaVersion := "2.13.6"
 
-testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+(Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 
 libraryDependencies += guice
 

--- a/play-java-grpc-example/build.sbt
+++ b/play-java-grpc-example/build.sbt
@@ -42,8 +42,8 @@ lazy val `play-java-grpc-example` = (project in file("."))
           ExecCmd("RUN", "apk", "add", "--no-cache", "bash")
         ) ++
         dockerCommands.value.tail ,
-    dockerAliases in Docker += DockerAlias(None, None, "play-java-grpc-example", None),
-    packageName in Docker := "play-java-grpc-example",
+    (Docker / dockerAliases) += DockerAlias(None, None, "play-java-grpc-example", None),
+    (Docker / packageName) := "play-java-grpc-example",
   )
   .settings(
     libraryDependencies ++= CompileDeps ++ TestDeps
@@ -70,7 +70,7 @@ val TestDeps = Seq(
 )
 
 // Make verbose tests
-testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+(Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 
 // Documentation for this project:
 //    sbt "project docs" "~ paradox"

--- a/play-java-rest-api-example/build.sbt
+++ b/play-java-rest-api-example/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       "net.jodah" % "failsafe" % "2.3.1",
     ),
     PlayKeys.externalizeResources := false,
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
+    (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",

--- a/play-java-starter-example/build.sbt
+++ b/play-java-starter-example/build.sbt
@@ -20,5 +20,5 @@ lazy val root = (project in file("."))
       "-Werror"
     ),
     // Make verbose tests
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+    (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
   )

--- a/play-java-telemetry-example/build.sbt
+++ b/play-java-telemetry-example/build.sbt
@@ -21,7 +21,7 @@ lazy val root = (project in file("."))
       "-Werror"
     ),
     // Make verbose tests
-    testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+    (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
   ).settings(
     libraryDependencies ++= Seq(
       Cinnamon.library.cinnamonCHMetrics, // only needed to use the Console reporter

--- a/play-scala-grpc-example/build.sbt
+++ b/play-scala-grpc-example/build.sbt
@@ -43,8 +43,8 @@ lazy val `play-scala-grpc-example` = (project in file("."))
           ExecCmd("RUN", "apk", "add", "--no-cache", "bash")
         ) ++
         dockerCommands.value.tail ,
-      dockerAliases in Docker += DockerAlias(None, None, "play-scala-grpc-example", None),
-      packageName in Docker := "play-scala-grpc-example",
+      (Docker / dockerAliases) += DockerAlias(None, None, "play-scala-grpc-example", None),
+      (Docker / packageName) := "play-scala-grpc-example",
     )
     .settings(
       libraryDependencies ++= CompileDeps ++ TestDeps
@@ -73,7 +73,7 @@ scalaVersion := "2.12.13"
 scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked")
 
 // Make verbose tests
-testOptions in Test := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
+(Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 
 // Documentation for this project:
 //    sbt "project docs" "~ paradox"

--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -9,20 +9,20 @@ lazy val databasePassword = sys.env.getOrElse("DB_DEFAULT_PASSWORD", "")
 
 val FlywayVersion = "6.2.2"
 
-version in ThisBuild := "1.1-SNAPSHOT"
+(ThisBuild / version) := "1.1-SNAPSHOT"
 
-resolvers in ThisBuild += Resolver.sonatypeRepo("releases")
-resolvers in ThisBuild += Resolver.sonatypeRepo("snapshots")
+(ThisBuild / resolvers) += Resolver.sonatypeRepo("releases")
+(ThisBuild / resolvers) += Resolver.sonatypeRepo("snapshots")
 
-libraryDependencies in ThisBuild ++= Seq(
+(ThisBuild / libraryDependencies) ++= Seq(
   "javax.inject" % "javax.inject" % "1",
   "joda-time" % "joda-time" % "2.10.2",
   "org.joda" % "joda-convert" % "2.2.1",
   "com.google.inject" % "guice" % "4.2.3"
 )
 
-scalaVersion in ThisBuild := "2.13.6"
-scalacOptions in ThisBuild ++= Seq(
+(ThisBuild / scalaVersion) := "2.13.6"
+(ThisBuild / scalacOptions) ++= Seq(
   "-encoding", "UTF-8", // yes, this is 2 args
   "-deprecation",
   "-feature",
@@ -30,7 +30,7 @@ scalacOptions in ThisBuild ++= Seq(
   "-Xlint",
   "-Ywarn-numeric-widen"
 )
-javacOptions in ThisBuild ++= Seq("-source", "1.8", "-target", "1.8")
+(ThisBuild / javacOptions) ++= Seq("-source", "1.8", "-target", "1.8")
 
 lazy val flyway = (project in file("modules/flyway"))
   .enablePlugins(FlywayPlugin)
@@ -80,7 +80,7 @@ lazy val slick = (project in file("modules/slick"))
         }
       }
     },
-    sourceGenerators in Compile += slickCodegen.taskValue
+    (Compile / sourceGenerators) += slickCodegen.taskValue
   )
   .aggregate(api)
   .dependsOn(api)
@@ -97,7 +97,7 @@ lazy val root = (project in file("."))
       "org.flywaydb" % "flyway-core" % FlywayVersion % Test,
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
     ),
-    fork in Test := true
+    (Test / fork) := true
   )
   .aggregate(slick)
   .dependsOn(slick)

--- a/play-scala-slick-example/build.sbt
+++ b/play-scala-slick-example/build.sbt
@@ -26,11 +26,11 @@ def sampleProject(name: String) =
         "com.h2database" % "h2" % "1.4.200",
         specs2 % Test,
       ),
-      concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
+      (Global / concurrentRestrictions) += Tags.limit(Tags.Test, 1)
     )
-    .settings(javaOptions in Test += "-Dslick.dbs.default.connectionTimeout=30 seconds")
+    .settings((Test / javaOptions) += "-Dslick.dbs.default.connectionTimeout=30 seconds")
     // We use a slightly different database URL for running the slick applications and testing the slick applications.
-    .settings(javaOptions in Test ++= Seq("-Dconfig.file=conf/test.conf"))
+    .settings((Test / javaOptions) ++= Seq("-Dconfig.file=conf/test.conf"))
 
 lazy val computerDatabaseSample = sampleProject("computer-database")
 

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -21,15 +21,15 @@ lazy val root = (project in file("."))
   .settings(
     name := """play-scala-tls-example""",
     version := "1.0.0",
-    fork in run := true,
+    (run / fork) := true,
     
     // Uncomment if you want to run "./play client" explicitly without SNI.
     //javaOptions in run += "-Djsse.enableSNIExtension=false"
-    javaOptions in run += "-Djavax.net.debug=ssl:handshake",
+    (run / javaOptions) += "-Djavax.net.debug=ssl:handshake",
 
     // Must not run tests in fork because the `play` script sets
     // some JVM properties (-D) which tests need.
-    fork in Test := false,
+    (Test / fork) := false,
 
     libraryDependencies ++= Seq(
       ws,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2


### PR DESCRIPTION
As per title, done like so;

```
scalafix --rules=https://gist.githubusercontent.com/eed3si9n/57e83f5330592d968ce49f0d5030d4d5/raw/7f576f16a90e432baa49911c9a66204c354947bb/Sbt0_13BuildSyntax.scala $( find ./ -type f -name '*.sbt' )
```

