### PR TITLE
Remove old h2 db before running tests to avoid problems with flyway

### DIFF
--- a/play-scala-isolated-slick-example/scripts/test-sbt
+++ b/play-scala-isolated-slick-example/scripts/test-sbt
@@ -3,4 +3,5 @@
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |"
 echo "+----------------------------+"
+rm -f test.mv.db
 sbt ++$TRAVIS_SCALA_VERSION clean flyway/flywayMigrate slickCodegen test


### PR DESCRIPTION
Doesn't matter for CI but for local testing only. Flyway failed with an exception because the old db was still there, containing old flyway meta data, but flyway was upgraded... 