### PR TITLE
Add scalaVersion setting to root project in play-scala-slick-example

### DIFF
--- a/play-scala-slick-example/build.sbt
+++ b/play-scala-slick-example/build.sbt
@@ -1,7 +1,8 @@
 lazy val root = (project in file("."))
   .settings(
     name := "play-scala-slick-examples",
-    version := "2.8.x"
+    version := "2.8.x",
+    scalaVersion := "2.13.10",
   )
   .aggregate(
     basicSample,


### PR DESCRIPTION
Test where failling because sbt ++$MATRIX_SCALA was defaulting to `2.12.x` instead of `2.13.x`. The version is now specified in the root and the subprojects.