### PR TITLE
Env variable condition added to test script

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-
+if [ -z "$MATRIX_SCALA" ]; then
+    echo "Error: the environment variable MATRIX_SCALA is not set"
+    exit 1
+fi
 pushd play-java-chatroom-example        && scripts/test-sbt && popd
 pushd play-java-compile-di-example      && scripts/test-sbt && popd
 pushd play-java-dagger2-example         && scripts/test-sbt && popd


### PR DESCRIPTION
A new condition in the `test.sh` test script to ensure that the MATRIX_SCALA environment variable is defined