### PR TITLE
Migrate samples scala3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ RUNNING_PID
 # metals
 project/metals.sbt
 .metals
+*/project/metals.sbt
+*/.metals
 
 # vs code
 .vscode
@@ -18,6 +20,7 @@ project/metals.sbt
 
 # sbt
 project/project/
+*/project/project/
 project/target/
 target/
 

--- a/play-java-akka-cluster-example/build.sbt
+++ b/play-java-akka-cluster-example/build.sbt
@@ -1,8 +1,5 @@
 import play.core.PlayVersion
 
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 name := """play-java-akka-cluster-example"""
 organization := "com.example"
 
@@ -10,8 +7,9 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := scala213
-crossScalaVersions := Seq(scala213, scala3)
+crossScalaVersions := Seq("2.13.10", "3.3.0-RC3")
+
+scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies += guice
 

--- a/play-java-akka-cluster-example/build.sbt
+++ b/play-java-akka-cluster-example/build.sbt
@@ -3,6 +3,24 @@ import play.core.PlayVersion
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
+lazy val core = Seq(
+  guice,
+)
+
+lazy val akkaVersion =  "2.6.20"
+
+lazy val akkaDeps = Seq(
+// Some Akka overrides to align versions of artifacts
+  ("com.typesafe.akka" %% "akka-stream" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  ("com.typesafe.akka" %% "akka-actor" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  // this dependency is required to form the Akka Cluster
+  ("com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  // Sending messages from a node to another in the Akka Cluster requires serializing. This
+  // example application uses the default Akka Jackson serializer with the CBOR format.
+  // See also `conf/serialization.conf` and `services.CborSerializable` for more info.
+  ("com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion).cross(CrossVersion.for3Use2_13),
+)
+
 name := """play-java-akka-cluster-example"""
 organization := "com.example"
 
@@ -13,21 +31,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 scalaVersion := scala213
 crossScalaVersions := Seq(scala213, scala3)
 
-libraryDependencies += guice
-
-val akkaVersion =  "2.6.20"
-
-// Some Akka overrides to align versions of artifacts
-libraryDependencies ++= Seq(
-  ("com.typesafe.akka" %% "akka-stream" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  ("com.typesafe.akka" %% "akka-actor" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  // this dependency is required to form the Akka Cluster
-  ("com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  // Sending messages from a node to another in the Akka Cluster requires serializing. This
-  // example application uses the default Akka Jackson serializer with the CBOR format.
-  // See also `conf/serialization.conf` and `services.CborSerializable` for more info.
-  ("com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion).cross(CrossVersion.for3Use2_13),
-)
+libraryDependencies ++= core ++ akkaDeps
 
 excludeDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/play-java-akka-cluster-example/build.sbt
+++ b/play-java-akka-cluster-example/build.sbt
@@ -3,24 +3,6 @@ import play.core.PlayVersion
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
-lazy val core = Seq(
-  guice,
-)
-
-lazy val akkaVersion =  "2.6.20"
-
-lazy val akkaDeps = Seq(
-// Some Akka overrides to align versions of artifacts
-  ("com.typesafe.akka" %% "akka-stream" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  ("com.typesafe.akka" %% "akka-actor" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  // this dependency is required to form the Akka Cluster
-  ("com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion).cross(CrossVersion.for3Use2_13),
-  // Sending messages from a node to another in the Akka Cluster requires serializing. This
-  // example application uses the default Akka Jackson serializer with the CBOR format.
-  // See also `conf/serialization.conf` and `services.CborSerializable` for more info.
-  ("com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion).cross(CrossVersion.for3Use2_13),
-)
-
 name := """play-java-akka-cluster-example"""
 organization := "com.example"
 
@@ -31,14 +13,13 @@ lazy val root = (project in file(".")).enablePlugins(PlayJava)
 scalaVersion := scala213
 crossScalaVersions := Seq(scala213, scala3)
 
-libraryDependencies ++= core ++ akkaDeps
+libraryDependencies += guice
 
-excludeDependencies ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((3, _)) =>
-      Seq(
-        ExclusionRule("com.typesafe", "ssl-config-core_2.13"),
-      )
-    case _ => Nil
-  }
-}
+val akkaVersion =  PlayVersion.akkaVersion
+
+// this dependency is required to form the Akka Cluster
+libraryDependencies += ("com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion).cross(CrossVersion.for3Use2_13)
+
+// Sending messages from a node to another in the Akka Cluster requires serializing. This
+// example application uses the default Akka Jackson serializer with the CBOR format.
+// See also `conf/serialization.conf` and `services.CborSerializable` for more info.

--- a/play-java-akka-cluster-example/build.sbt
+++ b/play-java-akka-cluster-example/build.sbt
@@ -1,5 +1,8 @@
 import play.core.PlayVersion
 
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 name := """play-java-akka-cluster-example"""
 organization := "com.example"
 
@@ -7,22 +10,31 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.13.10"
+scalaVersion := scala213
+crossScalaVersions := Seq(scala213, scala3)
 
 libraryDependencies += guice
 
-val akkaVersion =  PlayVersion.akkaVersion
+val akkaVersion =  "2.6.20"
 
 // Some Akka overrides to align versions of artifacts
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+  ("com.typesafe.akka" %% "akka-stream" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  ("com.typesafe.akka" %% "akka-actor" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  // this dependency is required to form the Akka Cluster
+  ("com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion).cross(CrossVersion.for3Use2_13),
+  // Sending messages from a node to another in the Akka Cluster requires serializing. This
+  // example application uses the default Akka Jackson serializer with the CBOR format.
+  // See also `conf/serialization.conf` and `services.CborSerializable` for more info.
+  ("com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion).cross(CrossVersion.for3Use2_13),
 )
 
-// this dependency is required to form the Akka Cluster
-libraryDependencies += "com.typesafe.akka" %% "akka-cluster-typed" % akkaVersion
-
-// Sending messages from a node to another in the Akka Cluster requires serializing. This
-// example application uses the default Akka Jackson serializer with the CBOR format.
-// See also `conf/serialization.conf` and `services.CborSerializable` for more info.
-libraryDependencies += "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion
+excludeDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _)) =>
+      Seq(
+        ExclusionRule("com.typesafe", "ssl-config-core_2.13"),
+      )
+    case _ => Nil
+  }
+}

--- a/play-java-akka-cluster-example/project/plugins.sbt
+++ b/play-java-akka-cluster-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-java-akka-cluster-example/project/plugins.sbt
+++ b/play-java-akka-cluster-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -1,22 +1,10 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := """play-java-chatroom-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-Xsource:3",
-          )
-        case _ => Nil
-      }
-    },
+    crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+    scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Seq(
       "org.webjars" %% "webjars-play" % "2.9.0-M3",
       "org.webjars" % "flot" % "0.8.3",

--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       }
     },
     libraryDependencies ++= Seq(
-      "org.webjars" %% "webjars-play" % "2.8.18",
+      "org.webjars" %% "webjars-play" % "2.9.0-M3-SNAPSHOT",
       "org.webjars" % "flot" % "0.8.3",
       "org.webjars" % "bootstrap" % "3.4.1",
       guice,
@@ -26,16 +26,6 @@ lazy val root = (project in file("."))
       "org.assertj" % "assertj-core" % "3.12.2" % Test,
       "org.awaitility" % "awaitility" % "3.1.6" % Test
     ),
-    excludeDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) =>
-          Seq(
-            ExclusionRule("org.scala-lang", "scala-xml_2.13"),
-            ExclusionRule("com.typesafe.play", "twirl-api_2.13"),
-          )
-        case _ => Nil
-      }
-    },
     // Needed to make JUnit report the tests being run
     (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(

--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -1,9 +1,22 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := """play-java-chatroom-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-Xsource:3",
+          )
+        case _ => Nil
+      }
+    },
     libraryDependencies ++= Seq(
       "org.webjars" %% "webjars-play" % "2.8.18",
       "org.webjars" % "flot" % "0.8.3",
@@ -13,6 +26,16 @@ lazy val root = (project in file("."))
       "org.assertj" % "assertj-core" % "3.12.2" % Test,
       "org.awaitility" % "awaitility" % "3.1.6" % Test
     ),
+    excludeDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) =>
+          Seq(
+            ExclusionRule("org.scala-lang", "scala-xml_2.13"),
+            ExclusionRule("com.typesafe.play", "twirl-api_2.13"),
+          )
+        case _ => Nil
+      }
+    },
     // Needed to make JUnit report the tests being run
     (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(

--- a/play-java-chatroom-example/build.sbt
+++ b/play-java-chatroom-example/build.sbt
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       }
     },
     libraryDependencies ++= Seq(
-      "org.webjars" %% "webjars-play" % "2.9.0-M3-SNAPSHOT",
+      "org.webjars" %% "webjars-play" % "2.9.0-M3",
       "org.webjars" % "flot" % "0.8.3",
       "org.webjars" % "bootstrap" % "3.4.1",
       guice,

--- a/play-java-chatroom-example/project/plugins.sbt
+++ b/play-java-chatroom-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-java-chatroom-example/project/plugins.sbt
+++ b/play-java-chatroom-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-java-forms-example/app/views/index.scala.html
+++ b/play-java-forms-example/app/views/index.scala.html
@@ -3,7 +3,7 @@
   @main("Welcome to Play") {
     <div>
       <ul>
-        <li>Please go to <a href="@routes.WidgetController.listWidgets">@routes.WidgetController.listWidgets</a></li>
+        <li>Please go to <a href="@routes.WidgetController.listWidgets()">@routes.WidgetController.listWidgets()</a></li>
       </ul>
 
     </div>

--- a/play-java-forms-example/app/views/listWidgets.scala.html
+++ b/play-java-forms-example/app/views/listWidgets.scala.html
@@ -25,14 +25,14 @@
 
     @* Global errors are not tied to any particular form field *@
     @if(form.hasGlobalErrors) {
-        @form.globalErrors.asScala.map { error: play.data.validation.ValidationError =>
+        @form.globalErrors.asScala.map { (error: play.data.validation.ValidationError) =>
             <div>
                 @error.key: @error.message
             </div>
         }
     }
 
-    @helper.form(routes.WidgetController.createWidget) {
+    @helper.form(routes.WidgetController.createWidget()) {
         @helper.CSRF.formField
 
         @helper.inputText(form("name"))

--- a/play-java-forms-example/build.sbt
+++ b/play-java-forms-example/build.sbt
@@ -2,31 +2,17 @@ name := """play-java-forms-example"""
 
 version := "1.0-SNAPSHOT"
 
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := scala213
-crossScalaVersions := Seq(scala213, scala3)
+crossScalaVersions := Seq("2.13.10", "3.3.0-RC3")
+
+scalaVersion := crossScalaVersions.value.head
 
 (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 
 libraryDependencies += guice
 
-scalacOptions ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, _)) =>
-      Seq(
-        "-encoding",
-        "utf-8",
-        "-Xfatal-warnings",
-        "-deprecation",
-        "-Xsource:3"
-      )
-    case _ => Nil
-  }
-}
+scalacOptions ++= List("-Werror")
 javacOptions ++= Seq(
   "-Xlint:unchecked",
   "-Xlint:deprecation",

--- a/play-java-forms-example/build.sbt
+++ b/play-java-forms-example/build.sbt
@@ -2,16 +2,31 @@ name := """play-java-forms-example"""
 
 version := "1.0-SNAPSHOT"
 
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.13.10"
+scalaVersion := scala213
+crossScalaVersions := Seq(scala213, scala3)
 
 (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v"))
 
 libraryDependencies += guice
 
-// disabled until https://github.com/playframework/playframework/issues/9845 is solved
-//scalacOptions ++= List("-encoding", "utf8", "-Xfatal-warnings", "-deprecation")
+scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _)) =>
+      Seq(
+        "-encoding",
+        "utf-8",
+        "-Xfatal-warnings",
+        "-deprecation",
+        "-Xsource:3"
+      )
+    case _ => Nil
+  }
+}
 javacOptions ++= Seq(
   "-Xlint:unchecked",
   "-Xlint:deprecation",

--- a/play-java-forms-example/project/plugins.sbt
+++ b/play-java-forms-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-java-forms-example/project/plugins.sbt
+++ b/play-java-forms-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-java-hello-world-tutorial/build.sbt
+++ b/play-java-hello-world-tutorial/build.sbt
@@ -3,8 +3,22 @@ organization := "com.example"
 
 version := "1.0-SNAPSHOT"
 
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.13.10"
+scalaVersion := scala213
+crossScalaVersions := Seq(scala213, scala3)
+
+scalacOptions ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _)) =>
+      Seq(
+        "-Xsource:3",
+      )
+    case _ => Nil
+  }
+}
 
 libraryDependencies += guice

--- a/play-java-hello-world-tutorial/build.sbt
+++ b/play-java-hello-world-tutorial/build.sbt
@@ -3,22 +3,10 @@ organization := "com.example"
 
 version := "1.0-SNAPSHOT"
 
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := scala213
-crossScalaVersions := Seq(scala213, scala3)
+crossScalaVersions := Seq("2.13.10", "3.3.0-RC3")
 
-scalacOptions ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, _)) =>
-      Seq(
-        "-Xsource:3",
-      )
-    case _ => Nil
-  }
-}
+scalaVersion := crossScalaVersions.value.head
 
 libraryDependencies += guice

--- a/play-java-hello-world-tutorial/project/plugins.sbt
+++ b/play-java-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-java-hello-world-tutorial/project/plugins.sbt
+++ b/play-java-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-java-jpa-example/app/controllers/PersonController.java
+++ b/play-java-jpa-example/app/controllers/PersonController.java
@@ -3,7 +3,7 @@ package controllers;
 import models.Person;
 import models.PersonRepository;
 import play.data.FormFactory;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
@@ -16,17 +16,17 @@ import static play.libs.Json.toJson;
 
 /**
  * The controller keeps all database operations behind the repository, and uses
- * {@link play.libs.concurrent.HttpExecutionContext} to provide access to the
+ * {@link play.libs.concurrent.ClassLoaderExecutionContext} to provide access to the
  * {@link play.mvc.Http.Context} methods like {@code request()} and {@code flash()}.
  */
 public class PersonController extends Controller {
 
     private final FormFactory formFactory;
     private final PersonRepository personRepository;
-    private final HttpExecutionContext ec;
+    private final ClassLoaderExecutionContext ec;
 
     @Inject
-    public PersonController(FormFactory formFactory, PersonRepository personRepository, HttpExecutionContext ec) {
+    public PersonController(FormFactory formFactory, PersonRepository personRepository, ClassLoaderExecutionContext ec) {
         this.formFactory = formFactory;
         this.personRepository = personRepository;
         this.ec = ec;

--- a/play-java-jpa-example/build.sbt
+++ b/play-java-jpa-example/build.sbt
@@ -1,13 +1,10 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := """play-java-jpa-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
+    crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+    scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Seq(
       guice,
       javaJpa,
@@ -19,16 +16,7 @@ lazy val root = (project in file("."))
       "org.mockito" % "mockito-core" % "5.2.0" % "test",
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-feature",
-            "-Xsource:3"
-          )
-        case _ => Nil
-      }
-    },
-    javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
+    scalacOptions ++= List("-feature", "-Werror"),
+    javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation", "-Werror"),
     PlayKeys.externalizeResourcesExcludes += baseDirectory.value / "conf" / "META-INF" / "persistence.xml"
   )

--- a/play-java-jpa-example/build.sbt
+++ b/play-java-jpa-example/build.sbt
@@ -1,9 +1,13 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := """play-java-jpa-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
       javaJpa,
@@ -15,7 +19,16 @@ lazy val root = (project in file("."))
       "org.mockito" % "mockito-core" % "5.2.0" % "test",
     ),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
-    scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked"),
-    javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation", "-Werror"),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-feature",
+            "-Xsource:3"
+          )
+        case _ => Nil
+      }
+    },
+    javacOptions ++= List("-Xlint:unchecked", "-Xlint:deprecation"),
     PlayKeys.externalizeResourcesExcludes += baseDirectory.value / "conf" / "META-INF" / "persistence.xml"
   )

--- a/play-java-jpa-example/project/plugins.sbt
+++ b/play-java-jpa-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")

--- a/play-java-jpa-example/project/plugins.sbt
+++ b/play-java-jpa-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.2")

--- a/play-java-jpa-example/test/UnitTest.java
+++ b/play-java-jpa-example/test/UnitTest.java
@@ -12,7 +12,7 @@ import play.i18n.Lang;
 import play.i18n.Messages;
 import play.i18n.MessagesApi;
 import play.libs.Json;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.test.Helpers;
@@ -47,7 +47,7 @@ public class UnitTest {
 
         PersonRepository repository = mock(PersonRepository.class);
         FormFactory formFactory = mock(FormFactory.class);
-        HttpExecutionContext ec = new HttpExecutionContext(ForkJoinPool.commonPool());
+        ClassLoaderExecutionContext ec = new ClassLoaderExecutionContext(ForkJoinPool.commonPool());
         final PersonController controller = new PersonController(formFactory, repository, ec);
         final Result result = controller.index(request.build());
 
@@ -87,7 +87,7 @@ public class UnitTest {
         FormFactory formFactory = new FormFactory(messagesApi, new Formatters(messagesApi), validatorFactory, config);
 
         // It is okay to use commonPool here since this is just a test.
-        HttpExecutionContext ec = new HttpExecutionContext(ForkJoinPool.commonPool());
+        ClassLoaderExecutionContext ec = new ClassLoaderExecutionContext(ForkJoinPool.commonPool());
 
         // Create controller and call method under test:
         final PersonController controller = new PersonController(formFactory, repository, ec);

--- a/play-java-rest-api-example/app/v1/post/PostAction.java
+++ b/play-java-rest-api-example/app/v1/post/PostAction.java
@@ -7,7 +7,7 @@ import net.jodah.failsafe.FailsafeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.libs.concurrent.Futures;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -27,12 +27,12 @@ public class PostAction extends play.mvc.Action.Simple {
 
     private final Meter requestsMeter;
     private final Timer responsesTimer;
-    private final HttpExecutionContext ec;
+    private final ClassLoaderExecutionContext ec;
     private final Futures futures;
 
     @Singleton
     @Inject
-    public PostAction(MetricRegistry metrics, HttpExecutionContext ec, Futures futures) {
+    public PostAction(MetricRegistry metrics, ClassLoaderExecutionContext ec, Futures futures) {
         this.ec = ec;
         this.futures = futures;
         this.requestsMeter = metrics.meter("requestsMeter");

--- a/play-java-rest-api-example/app/v1/post/PostController.java
+++ b/play-java-rest-api-example/app/v1/post/PostController.java
@@ -2,7 +2,7 @@ package v1.post;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import play.libs.Json;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.*;
 
 import javax.inject.Inject;
@@ -13,11 +13,11 @@ import java.util.stream.Collectors;
 @With(PostAction.class)
 public class PostController extends Controller {
 
-    private HttpExecutionContext ec;
+    private ClassLoaderExecutionContext ec;
     private PostResourceHandler handler;
 
     @Inject
-    public PostController(HttpExecutionContext ec, PostResourceHandler handler) {
+    public PostController(ClassLoaderExecutionContext ec, PostResourceHandler handler) {
         this.ec = ec;
         this.handler = handler;
     }

--- a/play-java-rest-api-example/app/v1/post/PostResourceHandler.java
+++ b/play-java-rest-api-example/app/v1/post/PostResourceHandler.java
@@ -1,7 +1,7 @@
 package v1.post;
 
 import com.palominolabs.http.url.UrlBuilder;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.mvc.Http;
 
 import javax.inject.Inject;
@@ -16,10 +16,10 @@ import java.util.stream.Stream;
 public class PostResourceHandler {
 
     private final PostRepository repository;
-    private final HttpExecutionContext ec;
+    private final ClassLoaderExecutionContext ec;
 
     @Inject
-    public PostResourceHandler(PostRepository repository, HttpExecutionContext ec) {
+    public PostResourceHandler(PostRepository repository, ClassLoaderExecutionContext ec) {
         this.repository = repository;
         this.ec = ec;
     }

--- a/play-java-rest-api-example/build.sbt
+++ b/play-java-rest-api-example/build.sbt
@@ -1,9 +1,13 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := "play-java-rest-api-example",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
       javaJpa,
@@ -13,20 +17,29 @@ lazy val root = (project in file("."))
       "com.palominolabs.http" % "url-builder" % "1.1.5",
       "net.jodah" % "failsafe" % "2.4.4",
     ),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-Xsource:3"
+          )
+        case _ => Nil
+      }
+    },
     PlayKeys.externalizeResources := false,
     (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",
-      "-Werror"
     )
   )
 
-val gatlingVersion = "3.3.1"
+val gatlingVersion = "3.9.2"
 lazy val gatling = (project in file("gatling"))
   .enablePlugins(GatlingPlugin)
   .settings(
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test,
       "io.gatling" % "gatling-test-framework" % gatlingVersion % Test

--- a/play-java-rest-api-example/build.sbt
+++ b/play-java-rest-api-example/build.sbt
@@ -17,20 +17,12 @@ lazy val root = (project in file("."))
       "com.palominolabs.http" % "url-builder" % "1.1.5",
       "net.jodah" % "failsafe" % "2.4.4",
     ),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-Xsource:3"
-          )
-        case _ => Nil
-      }
-    },
     PlayKeys.externalizeResources := false,
     (Test / testOptions) := Seq(Tests.Argument(TestFrameworks.JUnit, "-a", "-v")),
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",
+      "-Werror"
     )
   )
 

--- a/play-java-rest-api-example/project/plugins.sbt
+++ b/play-java-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
 
 // Load testing tool:
 // http://gatling.io/docs/2.2.2/extensions/sbt_plugin.html

--- a/play-java-rest-api-example/project/plugins.sbt
+++ b/play-java-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")
 
 // Load testing tool:
 // http://gatling.io/docs/2.2.2/extensions/sbt_plugin.html

--- a/play-java-rest-api-example/project/plugins.sbt
+++ b/play-java-rest-api-example/project/plugins.sbt
@@ -3,4 +3,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
 
 // Load testing tool:
 // http://gatling.io/docs/2.2.2/extensions/sbt_plugin.html
-addSbtPlugin("io.gatling" % "gatling-sbt" % "3.2.2")
+addSbtPlugin("io.gatling" % "gatling-sbt" % "4.3.0")

--- a/play-java-websocket-example/app/controllers/StockSentiment.java
+++ b/play-java-websocket-example/app/controllers/StockSentiment.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.typesafe.config.Config;
 import play.libs.Json;
 import play.libs.concurrent.Futures;
-import play.libs.concurrent.HttpExecutionContext;
+import play.libs.concurrent.ClassLoaderExecutionContext;
 import play.libs.ws.WSClient;
 import play.libs.ws.WSResponse;
 import play.mvc.Controller;
@@ -29,10 +29,10 @@ public class StockSentiment extends Controller {
     private final String sentimentUrl;
     private final String tweetUrl;
     private final WSClient wsClient;
-    private final HttpExecutionContext ec;
+    private final ClassLoaderExecutionContext ec;
 
     @Inject
-    public StockSentiment(WSClient wsClient, Config configuration, HttpExecutionContext ec) {
+    public StockSentiment(WSClient wsClient, Config configuration, ClassLoaderExecutionContext ec) {
         this.wsClient = wsClient;
         this.ec = ec;
         this.sentimentUrl = configuration.getString("sentiment.url");

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -1,9 +1,22 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := "play-java-websocket-example",
     version := "1.0",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-Xsource:3",
+          )
+        case _ => Nil
+      }
+    },
     // https://github.com/sbt/junit-interface
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     libraryDependencies ++= Seq(
@@ -17,10 +30,19 @@ lazy val root = (project in file("."))
       "org.assertj" % "assertj-core" % "3.24.2" % Test,
       "org.awaitility" % "awaitility" % "4.2.0" % Test,
     ),
+    excludeDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) =>
+          Seq(
+            ExclusionRule("org.scala-lang", "scala-xml_2.13"),
+            ExclusionRule("com.typesafe.play", "twirl-api_2.13"),
+          )
+        case _ => Nil
+      }
+    },
     LessKeys.compress := true,
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",
-      "-Werror"
     )
   )

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       guice,
       ws,
-      "org.webjars" %% "webjars-play" % "2.9.0-M3-SNAPSHOT",
+      "org.webjars" %% "webjars-play" % "2.9.0-M3",
       "org.webjars" % "bootstrap" % "2.3.2",
       "org.webjars" % "flot" % "0.8.3",
 

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -1,22 +1,10 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
   .settings(
     name := "play-java-websocket-example",
     version := "1.0",
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-Xsource:3",
-          )
-        case _ => Nil
-      }
-    },
+    crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+    scalaVersion := crossScalaVersions.value.head,
     // https://github.com/sbt/junit-interface
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
     libraryDependencies ++= Seq(

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       guice,
       ws,
-      "org.webjars" %% "webjars-play" % "2.8.18",
+      "org.webjars" %% "webjars-play" % "2.9.0-M3-SNAPSHOT",
       "org.webjars" % "bootstrap" % "2.3.2",
       "org.webjars" % "flot" % "0.8.3",
 
@@ -30,16 +30,6 @@ lazy val root = (project in file("."))
       "org.assertj" % "assertj-core" % "3.24.2" % Test,
       "org.awaitility" % "awaitility" % "4.2.0" % Test,
     ),
-    excludeDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) =>
-          Seq(
-            ExclusionRule("org.scala-lang", "scala-xml_2.13"),
-            ExclusionRule("com.typesafe.play", "twirl-api_2.13"),
-          )
-        case _ => Nil
-      }
-    },
     LessKeys.compress := true,
     javacOptions ++= Seq(
       "-Xlint:unchecked",

--- a/play-java-websocket-example/build.sbt
+++ b/play-java-websocket-example/build.sbt
@@ -44,5 +44,6 @@ lazy val root = (project in file("."))
     javacOptions ++= Seq(
       "-Xlint:unchecked",
       "-Xlint:deprecation",
+      "-Werror"
     )
   )

--- a/play-java-websocket-example/project/plugins.sbt
+++ b/play-java-websocket-example/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 

--- a/play-java-websocket-example/project/plugins.sbt
+++ b/play-java-websocket-example/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.2")
 

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -1,27 +1,17 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
     name := """play-scala-hello-world-tutorial""",
     organization := "com.example",
     version := "1.0-SNAPSHOT",
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
+    crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+    scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Seq(
       guice,
       "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test
     ),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-          case Some((2, _)) =>
-            Seq(
-              "-feature",
-              "-Xfatal-warnings",
-              "-Xsource:3",
-            )
-          case _ => Nil
-      }
-    }
+    scalacOptions ++= Seq(
+      "-feature",
+      "-Werror"
+    )
   )

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -1,14 +1,6 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
-lazy val core = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-)
-
-lazy val scala3Deps = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-)
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
@@ -19,13 +11,8 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test
     ),
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) => scala3Deps
-        case _ => core
-      }
-    },
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((2, _)) =>

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -1,17 +1,39 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
     name := """play-scala-hello-world-tutorial""",
     organization := "com.example",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test
     ),
-    scalacOptions ++= Seq(
-      "-feature",
-      "-deprecation",
-      "-Xfatal-warnings"
-    )
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test
+          )
+        case Some((3, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test
+          )
+        case _ => Nil
+      }
+    },
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((2, _)) =>
+            Seq(
+              "-feature",
+              "-Xfatal-warnings",
+              "-Xsource:3",
+            )
+          case _ => Nil
+      }
+    }
   )

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test
     ),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {

--- a/play-scala-hello-world-tutorial/build.sbt
+++ b/play-scala-hello-world-tutorial/build.sbt
@@ -1,6 +1,14 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
+lazy val core = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+)
+
+lazy val scala3Deps = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+)
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
@@ -14,15 +22,8 @@ lazy val root = (project in file("."))
     ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test
-          )
-        case Some((3, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test
-          )
-        case _ => Nil
+        case Some((3, _)) => scala3Deps
+        case _ => core
       }
     },
     scalacOptions ++= {

--- a/play-scala-hello-world-tutorial/project/plugins.sbt
+++ b/play-scala-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-scala-hello-world-tutorial/project/plugins.sbt
+++ b/play-scala-hello-world-tutorial/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-scala-rest-api-example/app/v1/post/PostController.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostController.scala
@@ -27,7 +27,7 @@ class PostController @Inject()(cc: PostControllerComponents)(
       mapping(
         "title" -> nonEmptyText,
         "body" -> text
-      )(PostFormInput.apply)(PostFormInput.unapply)
+      )(PostFormInput.apply)(t => Some(t.title, t.body))
     )
   }
 

--- a/play-scala-rest-api-example/app/v1/post/PostController.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostController.scala
@@ -10,7 +10,6 @@ import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class PostFormInput(title: String, body: String)
-
 object PostFormInput {
   def unapply(postFormInput: PostFormInput): Option[(String, String)] = {
     Some((postFormInput.title, postFormInput.body))

--- a/play-scala-rest-api-example/app/v1/post/PostController.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostController.scala
@@ -11,6 +11,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class PostFormInput(title: String, body: String)
 
+object PostFormInput {
+  def unapply(postFormInput: PostFormInput): Option[(String, String)] = {
+    Some((postFormInput.title, postFormInput.body))
+  }
+}
+
 /**
   * Takes HTTP requests and produces JSON.
   */
@@ -27,7 +33,7 @@ class PostController @Inject()(cc: PostControllerComponents)(
       mapping(
         "title" -> nonEmptyText,
         "body" -> text
-      )(PostFormInput.apply)(t => Some(t.title, t.body))
+      )(PostFormInput.apply)(PostFormInput.unapply)
     )
   }
 

--- a/play-scala-rest-api-example/app/v1/post/PostRouter.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostRouter.scala
@@ -13,8 +13,8 @@ class PostRouter @Inject()(controller: PostController) extends SimpleRouter {
   val prefix = "/v1/posts"
 
   def link(id: PostId): String = {
-    import io.lemonlabs.uri.Url
-    val url = s"${prefix}/${id.toString}"
+    import io.lemonlabs.uri.typesafe.dsl._
+    val url = prefix / id.toString
     url.toString()
   }
 

--- a/play-scala-rest-api-example/app/v1/post/PostRouter.scala
+++ b/play-scala-rest-api-example/app/v1/post/PostRouter.scala
@@ -13,8 +13,8 @@ class PostRouter @Inject()(controller: PostController) extends SimpleRouter {
   val prefix = "/v1/posts"
 
   def link(id: PostId): String = {
-    import io.lemonlabs.uri.typesafe.dsl._
-    val url = prefix / id.toString
+    import io.lemonlabs.uri.Url
+    val url = s"${prefix}/${id.toString}"
     url.toString()
   }
 

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -16,7 +16,7 @@ lazy val root = (project in file("."))
       "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
       "io.lemonlabs" %% "scala-uri" % "4.0.3",
       "net.codingwell" %% "scala-guice" % "5.1.1",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test
     ),
     scalacOptions ++= Seq(
       "-feature",

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -20,8 +20,7 @@ lazy val root = (project in file("."))
     ),
     scalacOptions ++= Seq(
       "-feature",
-//      "-deprecation",
-      "-Xfatal-warnings"
+      "-Werror"
     )
   )
 

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -4,30 +4,32 @@ import play.sbt.PlaySettings
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
+lazy val core = Seq(
+  guice,
+  "org.joda" % "joda-convert" % "2.2.3",
+  "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
+  "io.lemonlabs" %% "scala-uri" % "4.0.3",
+  "net.codingwell" %% "scala-guice" % "5.1.1",
+)
+
+lazy val scala2Deps = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+)
+
+lazy val scala3Deps= Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+)
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayService, PlayLayoutPlugin, Common)
   .settings(
     name := "play-scala-rest-api-example",
     scalaVersion := scala213,
     crossScalaVersions := Seq(scala213, scala3),
-    libraryDependencies ++= Seq(
-      guice,
-      "org.joda" % "joda-convert" % "2.2.3",
-      "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
-      "io.lemonlabs" %% "scala-uri" % "4.0.3",
-      "net.codingwell" %% "scala-guice" % "5.1.1",
-    ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-          )
-        case Some((3, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-          )
-        case _ => Nil
+        case Some((3, _)) => core ++ scala3Deps
+        case _ => core ++ scala2Deps
       }
     },
   )

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -4,34 +4,25 @@ import play.sbt.PlaySettings
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
-lazy val core = Seq(
-  guice,
-  "org.joda" % "joda-convert" % "2.2.3",
-  "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
-  "io.lemonlabs" %% "scala-uri" % "4.0.3",
-  "net.codingwell" %% "scala-guice" % "5.1.1",
-)
-
-lazy val scala2Deps = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-)
-
-lazy val scala3Deps= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-)
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayService, PlayLayoutPlugin, Common)
   .settings(
     name := "play-scala-rest-api-example",
     scalaVersion := scala213,
     crossScalaVersions := Seq(scala213, scala3),
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) => core ++ scala3Deps
-        case _ => core ++ scala2Deps
-      }
-    },
+    libraryDependencies ++= Seq(
+      guice,
+      "org.joda" % "joda-convert" % "2.2.3",
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
+      "io.lemonlabs" %% "scala-uri" % "4.0.3",
+      "net.codingwell" %% "scala-guice" % "5.1.1",
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test
+    ),
+    scalacOptions ++= Seq(
+      "-feature",
+//      "-deprecation",
+      "-Xfatal-warnings"
+    )
   )
 
 lazy val gatlingVersion = "3.9.2"

--- a/play-scala-rest-api-example/build.sbt
+++ b/play-scala-rest-api-example/build.sbt
@@ -1,31 +1,43 @@
 import sbt.Keys._
 import play.sbt.PlaySettings
 
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayService, PlayLayoutPlugin, Common)
   .settings(
     name := "play-scala-rest-api-example",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
       "org.joda" % "joda-convert" % "2.2.3",
       "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
       "io.lemonlabs" %% "scala-uri" % "4.0.3",
       "net.codingwell" %% "scala-guice" % "5.1.1",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test
     ),
-    scalacOptions ++= Seq(
-      "-feature",
-      "-deprecation",
-      "-Xfatal-warnings"
-    )
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+          )
+        case Some((3, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+          )
+        case _ => Nil
+      }
+    },
   )
 
-lazy val gatlingVersion = "3.3.1"
+lazy val gatlingVersion = "3.9.2"
 lazy val gatling = (project in file("gatling"))
   .enablePlugins(GatlingPlugin)
   .settings(
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       "io.gatling.highcharts" % "gatling-charts-highcharts" % gatlingVersion % Test,
       "io.gatling" % "gatling-test-framework" % gatlingVersion % Test
@@ -37,6 +49,7 @@ lazy val gatling = (project in file("gatling"))
 //    open docs/target/paradox/site/index.html
 lazy val docs = (project in file("docs")).enablePlugins(ParadoxPlugin).
   settings(
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     paradoxProperties += ("download_url" -> "https://example.lightbend.com/v1/download/play-samples-play-scala-rest-api-example")
   )

--- a/play-scala-rest-api-example/project/Common.scala
+++ b/play-scala-rest-api-example/project/Common.scala
@@ -14,18 +14,24 @@ object Common extends AutoPlugin {
     version := "1.0-SNAPSHOT",
     resolvers += Resolver.typesafeRepo("releases"),
     javacOptions ++= Seq("--release", "11"),
-    scalacOptions ++= Seq(
-      "-encoding",
-      "UTF-8", // yes, this is 2 args
-      "-release",
-      "11", // yes, this is 2 args (could also be done as -release:11 however)
-      "-deprecation",
-      "-feature",
-      "-unchecked",
-      "-Ywarn-numeric-widen",
-      "-Xfatal-warnings"
-    ),
-    scalacOptions in Test ++= Seq("-Yrangepos"),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-Ywarn-numeric-widen",
+            "-Xsource:3",
+            "-encoding",
+            "UTF-8", // yes, this is 2 args
+            "-release",
+            "11", // yes, this is 2 args (could also be done as -release:11 however)
+            "-deprecation",
+            "-feature",
+            "-unchecked",
+            "-Xfatal-warnings",
+          )
+        case _ => Nil
+      }
+    },
     autoAPIMappings := true
   )
 }

--- a/play-scala-rest-api-example/project/Common.scala
+++ b/play-scala-rest-api-example/project/Common.scala
@@ -14,24 +14,23 @@ object Common extends AutoPlugin {
     version := "1.0-SNAPSHOT",
     resolvers += Resolver.typesafeRepo("releases"),
     javacOptions ++= Seq("--release", "11"),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-Ywarn-numeric-widen",
-            "-Xsource:3",
-            "-encoding",
-            "UTF-8", // yes, this is 2 args
-            "-release",
-            "11", // yes, this is 2 args (could also be done as -release:11 however)
-            "-deprecation",
-            "-feature",
-            "-unchecked",
-            "-Xfatal-warnings",
-          )
-        case _ => Nil
-      }
-    },
+    scalacOptions ++= Seq(
+      "-release",
+      "11", // yes, this is 2 args (could also be done as -release:11 however)
+    ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, _)) =>
+        Seq(
+          "-Ywarn-numeric-widen",
+        )
+      case _ => Seq.empty
+    }),
+    scalacOptions in Test ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, _)) =>
+        Seq(
+          "-Yrangepos",
+        )
+      case _ => Seq.empty
+    }),
     autoAPIMappings := true
   )
 }

--- a/play-scala-rest-api-example/project/plugins.sbt
+++ b/play-scala-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
 
 // sbt-paradox, used for documentation
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.3")

--- a/play-scala-rest-api-example/project/plugins.sbt
+++ b/play-scala-rest-api-example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")
 
 // sbt-paradox, used for documentation
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.3")

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -1,29 +1,19 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
     name := """play-scala-starter-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scala213, scala3),
+    crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+    scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Seq(
       guice,
       "com.h2database" % "h2" % "2.1.214",
       "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test,
     ),
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "-feature",
-            "-Xfatal-warnings",
-            "-Xsource:3",
-          )
-        case _ => Nil
-      }
-    },
+    scalacOptions ++= Seq(
+      "-feature",
+      "-Xfatal-warnings"
+    ),
     // Needed for ssl-config to create self signed certificated under Java 17
     Test / javaOptions ++= List("--add-exports=java.base/sun.security.x509=ALL-UNNAMED"),
   )

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       guice,
       "com.h2database" % "h2" % "2.1.214",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test,
     ),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -1,14 +1,6 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
-lazy val core = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-)
-
-lazy val scala3Deps = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-)
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
@@ -19,13 +11,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       guice,
       "com.h2database" % "h2" % "2.1.214",
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test,
     ),
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) => scala3Deps
-        case _ => core
-      }
-    },
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -1,19 +1,41 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
     name := """play-scala-starter-example""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.10",
+    scalaVersion := scala213,
+    crossScalaVersions := Seq(scala213, scala3),
     libraryDependencies ++= Seq(
       guice,
       "com.h2database" % "h2" % "2.1.214",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test
     ),
-    scalacOptions ++= Seq(
-      "-feature",
-      "-deprecation",
-      "-Xfatal-warnings"
-    ),
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+          )
+        case Some((3, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+          )
+        case _ => Nil
+      }
+    },
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "-feature",
+            "-Xfatal-warnings",
+            "-Xsource:3",
+          )
+        case _ => Nil
+      }
+    },
     // Needed for ssl-config to create self signed certificated under Java 17
     Test / javaOptions ++= List("--add-exports=java.base/sun.security.x509=ALL-UNNAMED"),
   )

--- a/play-scala-starter-example/build.sbt
+++ b/play-scala-starter-example/build.sbt
@@ -1,6 +1,14 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
+lazy val core = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+)
+
+lazy val scala3Deps = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+)
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   .settings(
@@ -14,15 +22,8 @@ lazy val root = (project in file("."))
     ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-          )
-        case Some((3, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-          )
-        case _ => Nil
+        case Some((3, _)) => scala3Deps
+        case _ => core
       }
     },
     scalacOptions ++= {

--- a/play-scala-starter-example/project/plugins.sbt
+++ b/play-scala-starter-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-scala-starter-example/project/plugins.sbt
+++ b/play-scala-starter-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-scala-tls-example/app/controllers/HomeController.scala
+++ b/play-scala-tls-example/app/controllers/HomeController.scala
@@ -7,11 +7,11 @@ import play.api.mvc._
 
 class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
-  def index = Action { implicit request =>
+  def index: Action[AnyContent] = Action { implicit request =>
     Ok(views.html.index(subdomain)).withHeaders("Cache-Control" -> "no-store")
   }
 
-  private def subdomain(implicit r: Request[_]): String = {
+  private def subdomain(implicit r: RequestHeader): String = {
     // pull out the host part of the request URI
     val s = r.host.split(":")(0).replace(".example.com", "")
 

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -1,10 +1,21 @@
+lazy val scala213 = "2.13.10"
+lazy val scala3 = "3.3.0-RC3"
+
 val commonSettings = Seq(
-  scalaVersion := "2.13.10",
-  scalacOptions ++= Seq(
-    "-feature",
-    "-deprecation",
-    "-Xfatal-warnings"
-  )
+  scalaVersion := scala213,
+  crossScalaVersions := Seq(scala213, scala3),
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, _)) =>
+        Seq(
+          "-feature",
+          "-deprecation",
+          "-Xfatal-warnings",
+          "-Xsource:3",
+        )
+      case _ => Nil
+    }
+  }
 )
 
 lazy val one = (project in file("modules/one"))
@@ -34,8 +45,20 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       ws,
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-    )
+    ),
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+          )
+        case Some((3, _)) =>
+          Seq(
+            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+          )
+        case _ => Nil
+      }
+    }
   )
   .aggregate(one, two)
   .dependsOn(one, two)

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -45,7 +45,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       ws,
       guice,
-      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3" % Test,
     ),
   )
   .aggregate(one, two)

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -1,21 +1,10 @@
-lazy val scala213 = "2.13.10"
-lazy val scala3 = "3.3.0-RC3"
-
 val commonSettings = Seq(
-  scalaVersion := scala213,
-  crossScalaVersions := Seq(scala213, scala3),
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, _)) =>
-        Seq(
-          "-feature",
-          "-deprecation",
-          "-Xfatal-warnings",
-          "-Xsource:3",
-        )
-      case _ => Nil
-    }
-  }
+  crossScalaVersions := Seq("2.13.10", "3.3.0-RC3"),
+  scalaVersion := crossScalaVersions.value.head,
+  scalacOptions ++= Seq(
+    "-feature",
+    "-Werror"
+  )
 )
 
 lazy val one = (project in file("modules/one"))

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -1,14 +1,6 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
-lazy val core = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-)
-
-lazy val scala3Deps = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-)
-
 val commonSettings = Seq(
   scalaVersion := scala213,
   crossScalaVersions := Seq(scala213, scala3),
@@ -53,13 +45,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       ws,
       guice,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M3-SNAPSHOT" % Test,
     ),
-    libraryDependencies ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _)) => scala3Deps
-        case _ => core
-      }
-    }
   )
   .aggregate(one, two)
   .dependsOn(one, two)

--- a/play-scala-tls-example/build.sbt
+++ b/play-scala-tls-example/build.sbt
@@ -1,6 +1,14 @@
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.3.0-RC3"
 
+lazy val core = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
+)
+
+lazy val scala3Deps = Seq(
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
+)
+
 val commonSettings = Seq(
   scalaVersion := scala213,
   crossScalaVersions := Seq(scala213, scala3),
@@ -48,15 +56,8 @@ lazy val root = (project in file("."))
     ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2" % Test,
-          )
-        case Some((3, _)) =>
-          Seq(
-            "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.0-M2+0-d4697b31+20230227-1631-SNAPSHOT" % Test,
-          )
-        case _ => Nil
+        case Some((3, _)) => scala3Deps
+        case _ => core
       }
     }
   )

--- a/play-scala-tls-example/project/plugins.sbt
+++ b/play-scala-tls-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")

--- a/play-scala-tls-example/project/plugins.sbt
+++ b/play-scala-tls-example/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M3-SNAPSHOT")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0-M4")

--- a/play-scala-tls-example/test/integration/ServerSpec.scala
+++ b/play-scala-tls-example/test/integration/ServerSpec.scala
@@ -13,6 +13,7 @@ import org.scalatestplus.play._
 import play.api.libs.ws.WSResponse
 import play.api.libs.ws.ahc.AhcWSClient
 import play.api.libs.ws.ahc.AhcWSClientConfigFactory
+import play.api.libs.ws.WSBodyReadables.readableAsString
 
 import scala.concurrent.Future
 
@@ -23,7 +24,7 @@ class ServerSpec extends PlaySpec with GuiceOneHttpsServerPerTest with ScalaFutu
 
   val name = "testing"
   val system = ActorSystem(name)
-  implicit val materializer = Materializer.matFromSystem(system)
+  implicit val materializer: Materializer = Materializer.matFromSystem(system)
 
   val config = ConfigFactory.load("ws").withFallback(ConfigFactory.defaultReference())
   val wsConfig = AhcWSClientConfigFactory.forConfig(config)

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+MATRIX_SCALA="3.3.0-RC3"
 if [ -z "$MATRIX_SCALA" ]; then
     echo "Error: the environment variable MATRIX_SCALA is not set"
     exit 1

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-MATRIX_SCALA="3.3.0-RC3"
 if [ -z "$MATRIX_SCALA" ]; then
     echo "Error: the environment variable MATRIX_SCALA is not set"
     exit 1


### PR DESCRIPTION
### Working samples:
- play-java-forms-example
- play-java-hello-world-example
- play-java-jpa-example
- play-java-rest-api-example
- play-scala-hello-world-tutorial
- play-scala-starter-example
- play-scala-tls-example
- play-java-chatroom-example
- play-java-websocket-example
- play-scala-rest-api

I haven't included the samples where the Scala3 artifacts aren't available.