### PR TITLE
Use `eclipse-temurin:11-alpine` docker image

### DIFF
--- a/play-java-grpc-example/build.sbt
+++ b/play-java-grpc-example/build.sbt
@@ -35,11 +35,11 @@ lazy val `play-java-grpc-example` = (project in file("."))
   )
   .settings(
     // workaround to https://github.com/akka/akka-grpc/pull/470#issuecomment-442133680
-    dockerBaseImage := "openjdk:8-alpine",
+    dockerBaseImage := "eclipse-temurin:11-alpine",
     dockerCommands  :=
       Seq.empty[CmdLike] ++
         Seq(
-          Cmd("FROM", "openjdk:8-alpine"),
+          Cmd("FROM", "eclipse-temurin:11-alpine"),
           ExecCmd("RUN", "apk", "add", "--no-cache", "bash")
         ) ++
         dockerCommands.value.tail ,

--- a/play-scala-grpc-example/build.sbt
+++ b/play-scala-grpc-example/build.sbt
@@ -36,11 +36,11 @@ lazy val `play-scala-grpc-example` = (project in file("."))
     )
     .settings(
       // workaround to https://github.com/akka/akka-grpc/pull/470#issuecomment-442133680
-      dockerBaseImage := "openjdk:8-alpine",
+      dockerBaseImage := "eclipse-temurin:11-alpine",
       dockerCommands  :=
         Seq.empty[CmdLike] ++
         Seq(
-          Cmd("FROM", "openjdk:8-alpine"),
+          Cmd("FROM", "eclipse-temurin:11-alpine"),
           ExecCmd("RUN", "apk", "add", "--no-cache", "bash")
         ) ++
         dockerCommands.value.tail ,


### PR DESCRIPTION
Only for 2.9 branch, no backport.
https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=11-alpine