### PR TITLE
Update slick-joda-mapper to 2.6.0

### DIFF
--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -49,7 +49,7 @@ lazy val slick = (project in file("modules/slick"))
       "com.zaxxer" % "HikariCP" % "3.4.5",
       "com.typesafe.slick" %% "slick" % "3.3.3",
       "com.typesafe.slick" %% "slick-hikaricp" % "3.3.3",
-      "com.github.tototoshi" %% "slick-joda-mapper" % "2.4.2"
+      "com.github.tototoshi" %% "slick-joda-mapper" % "2.6.0"
     ),
 
     slickCodegenDatabaseUrl := databaseUrl,
@@ -62,13 +62,13 @@ lazy val slick = (project in file("modules/slick"))
 
     slickCodegenCodeGenerator := { (model: m.Model) =>
       new SourceCodeGenerator(model) {
-        override def code =
-          "import com.github.tototoshi.slick.H2JodaSupport._\n" + "import org.joda.time.DateTime\n" + super.code
-
         override def Table = new Table(_) {
+          override def TableClass = new TableClass {
+            override def parents = Seq("com.example.user.slick.JodaSupport")
+          }
           override def Column = new Column(_) {
             override def rawType = model.tpe match {
-              case "java.sql.Timestamp" => "DateTime" // kill j.s.Timestamp
+              case "java.sql.Timestamp" => "org.joda.time.DateTime" // kill j.s.Timestamp
               case _ =>
                 super.rawType
             }

--- a/play-scala-isolated-slick-example/modules/slick/src/main/scala/com/example/user/slick/JodaSupport.scala
+++ b/play-scala-isolated-slick-example/modules/slick/src/main/scala/com/example/user/slick/JodaSupport.scala
@@ -1,0 +1,16 @@
+package com.example.user.slick
+
+import org.joda.time.DateTime
+import slick.jdbc._
+import com.github.tototoshi.slick._
+
+trait JodaSupport {
+  private val driver: JdbcProfile = _root_.slick.jdbc.H2Profile
+
+  private val dateTimeMapperDelegate: JodaDateTimeMapper = new JodaDateTimeMapper(driver)
+  implicit val datetimeTypeMapper: JdbcProfile#DriverJdbcType[DateTime] = dateTimeMapperDelegate.TypeMapper
+  implicit val getDatetimeResult: GetResult[DateTime] = dateTimeMapperDelegate.JodaGetResult.getResult
+  implicit val getDatetimeOptionResult: GetResult[Option[DateTime]] = dateTimeMapperDelegate.JodaGetResult.getOptionResult
+  implicit val setDatetimeParameter: SetParameter[DateTime] = dateTimeMapperDelegate.JodaSetParameter.setJodaParameter
+  implicit val setDatetimeOptionParameter: SetParameter[Option[DateTime]] = dateTimeMapperDelegate.JodaSetParameter.setJodaOptionParameter
+}


### PR DESCRIPTION
To avoid implicit resolution conflicts, I have decided to mix-in a trait for supplying instances for Joda in the Table classes. I really want to mix in GenericJodaSupport provided by slick-joda-mapper. But GenericJodaSupport is a class, so I can't mix-in. I may modify slick-joda-mapper later. I think slick-joda-mapper's interface is not good.