### PR TITLE
Fix CSP in `play-java-streaming-example`

### DIFF
--- a/play-java-streaming-example/app/controllers/HomeController.scala
+++ b/play-java-streaming-example/app/controllers/HomeController.scala
@@ -7,7 +7,7 @@ import play.api.routing._
 
 class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
 
-  def index() = Action {
+  def index(): Action[AnyContent] = Action { implicit request =>
     Ok(views.html.index())
   }
 

--- a/play-java-streaming-example/app/controllers/JavaCometController.java
+++ b/play-java-streaming-example/app/controllers/JavaCometController.java
@@ -10,8 +10,8 @@ import javax.inject.Singleton;
 @Singleton
 public class JavaCometController extends Controller implements JavaTicker {
 
-    public Result index() {
-        return ok(views.html.javacomet.render());
+    public Result index(Http.Request request) {
+        return ok(views.html.javacomet.render(request.asScala()));
     }
 
     public Result streamClock() {

--- a/play-java-streaming-example/app/controllers/JavaEventSourceController.java
+++ b/play-java-streaming-example/app/controllers/JavaEventSourceController.java
@@ -11,8 +11,8 @@ import javax.inject.Singleton;
 @Singleton
 public class JavaEventSourceController extends Controller implements JavaTicker {
 
-    public Result index() {
-        return ok(views.html.javaeventsource.render());
+    public Result index(Http.Request request) {
+        return ok(views.html.javaeventsource.render(request.asScala()));
     }
 
     public Result streamClock() {

--- a/play-java-streaming-example/app/views/index.scala.html
+++ b/play-java-streaming-example/app/views/index.scala.html
@@ -1,4 +1,5 @@
-@()
+@import play.api.mvc.RequestHeader
+@()(implicit request: RequestHeader)
 
 @main {
 

--- a/play-java-streaming-example/app/views/javacomet.scala.html
+++ b/play-java-streaming-example/app/views/javacomet.scala.html
@@ -1,4 +1,6 @@
-@()
+@import play.api.mvc.RequestHeader
+@import views.html.helper.CSPNonce
+@()(implicit request: RequestHeader)
 
 @main {
 
@@ -10,8 +12,8 @@
         Clock events are pushed from the Server using a Comet connection.
     </p>
 
-    <script src="@routes.Assets.at("javascripts/comet.js")"></script>
+    <script @{CSPNonce.attr} src="@routes.Assets.at("javascripts/comet.js")"></script>
 
-    <iframe id="comet" src="@routes.JavaCometController.streamClock().unique()"></iframe>
+    <iframe id="comet" hidden src="@routes.JavaCometController.streamClock().unique()"></iframe>
 
 }

--- a/play-java-streaming-example/app/views/javaeventsource.scala.html
+++ b/play-java-streaming-example/app/views/javaeventsource.scala.html
@@ -1,4 +1,6 @@
-@()
+@import play.api.mvc.RequestHeader
+@import views.html.helper.CSPNonce
+@()(implicit request: RequestHeader)
 
 @main {
     <h1>Server Sent Event clock</h1>
@@ -9,5 +11,5 @@
         Clock events are pushed from the Server using a Server Sent Event connection.
     </p>
 
-    <script src="@routes.Assets.at("javascripts/eventsource.js")"></script>
+    <script @{CSPNonce.attr} src="@routes.Assets.at("javascripts/eventsource.js")"></script>
 }

--- a/play-java-streaming-example/app/views/main.scala.html
+++ b/play-java-streaming-example/app/views/main.scala.html
@@ -1,4 +1,6 @@
-@(content: Html)
+@import views.html.helper.CSPNonce
+@import play.api.mvc.RequestHeader
+@(content: Html)(implicit request: RequestHeader)
 
 <!DOCTYPE html>
 
@@ -7,8 +9,8 @@
         <title>EventSource clock</title>
         <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-        <script src="@routes.Assets.at("javascripts/jquery-3.2.0.slim.js")" type="text/javascript"></script>
-        <script type="text/javascript" src="@routes.HomeController.javascriptRoutes"></script>
+        <script @{CSPNonce.attr} src="@routes.Assets.at("javascripts/jquery-3.2.0.slim.js")" type="text/javascript"></script>
+        <script @{CSPNonce.attr} src="@routes.HomeController.javascriptRoutes" type="text/javascript"></script>
     </head>
     <body>
         @content

--- a/play-java-streaming-example/conf/routes
+++ b/play-java-streaming-example/conf/routes
@@ -6,10 +6,11 @@
 
 GET        /                                  controllers.HomeController.index()
 
-GET        /java/comet                         controllers.JavaCometController.index()
+GET        /java/comet                         controllers.JavaCometController.index(request: Request)
++ nocsp
 GET        /java/comet/liveClock               controllers.JavaCometController.streamClock()
 
-GET        /java/eventSource                   controllers.JavaEventSourceController.index()
+GET        /java/eventSource                   controllers.JavaEventSourceController.index(request: Request)
 GET        /java/eventSource/liveClock         controllers.JavaEventSourceController.streamClock()
 
 GET        /javascriptRoutes                  controllers.HomeController.javascriptRoutes

--- a/play-java-streaming-example/public/javascripts/eventsource.js
+++ b/play-java-streaming-example/public/javascripts/eventsource.js
@@ -4,5 +4,5 @@ if (!!window.EventSource) {
         $('#clock').html(e.data.replace(/(\d)/g, '<span>$1</span>'))
     });
 } else {
-    $("#clock").html("Sorry. This browser doesn't seem to support Server sent event. Check <a href='http://html5test.com/compare/feature/communication-eventSource.html'>html5test</a> for browser compatibility.");
+    $("#clock").html("Sorry. This browser doesn't seem to support Server sent event. Check <a href='https://html5test.com/compare/feature/communication.eventSource.html'>html5test</a> for browser compatibility.");
 }


### PR DESCRIPTION
It looks as if this example doesn't work 🤷‍♂️ I don't know when the errors started, but I catch them in Safari and Chrome.
@mkurz Can you check it? 
And I couldn't a solution for using SCPNonce with Comet (https://github.com/playframework/playframework/blob/c216b30560f8fc62ef46f94dedb89e1b92940ecb/core/play/src/main/scala/play/api/libs/Comet.scala#L89) and just disabled csp for comet script 😞 