### PR TITLE
Downgrade h2 database to make   play-scala-isolated-slick-example work

### DIFF
--- a/play-scala-isolated-slick-example/.gitignore
+++ b/play-scala-isolated-slick-example/.gitignore
@@ -1,1 +1,2 @@
 test.mv.db
+test.trace.db

--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -82,7 +82,9 @@ lazy val root = (project in file("."))
     TwirlKeys.templateImports += "com.example.user.User",
     libraryDependencies ++= Seq(
       guice,
-      "com.h2database" % "h2" % "2.2.224",
+      "com.h2database" % "h2" % "1.4.200", // Can't use latest h2 currently: flyway-sbt comes with an outdated flyway version that does not support h2 2.x yet...:
+      // https://github.com/flyway/flyway-sbt/blob/7fc35d2833531b2b9e5a98a594d76fd047a077a8/build.sbt#L1
+      // https://github.com/flyway/flyway-sbt/issues/82#issuecomment-1636728997
       ws % Test,
       "org.flywaydb" % "flyway-core" % FlywayVersion % Test,
       "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test

--- a/play-scala-isolated-slick-example/scripts/test-sbt
+++ b/play-scala-isolated-slick-example/scripts/test-sbt
@@ -3,5 +3,5 @@
 echo "+----------------------------+"
 echo "| Executing tests using sbt  |"
 echo "+----------------------------+"
-rm -f test.mv.db
+rm -f test.mv.db test.trace.db
 sbt ++$MATRIX_SCALA clean flyway/flywayMigrate slickCodegen test


### PR DESCRIPTION
Fixes
- [**playframework/discussions#12280:** Problem with play-samples/play-scala-isolated-slick-example](https://github.com/orgs/playframework/discussions/12280)

The problem is the flyway-sbt plugins comes with a very old flyway version which does not support h2 2.x yet... So when running `flyway/flywayMigrate` in `sbt` it uses that very old flyway version to generate the `test.mv.db` file, using H2 version 1.x (which the old flyway version depends on). However when starting `run` in sbt afterwards, the application now depends on H2 version 2.x which file format is not compatible anymore with its v1...

Hopefully this gets fixes soon:
- https://github.com/flyway/flyway-sbt/pull/91
- https://github.com/flyway/flyway-sbt/issues/90
- https://github.com/flyway/flyway-sbt/issues/82