### PR TITLE
[3.0.x] Remove deprecated `contentSecurityPolicy` config + deprecated hibernate.dialect config

### DIFF
--- a/play-java-chatroom-example/conf/application.conf
+++ b/play-java-chatroom-example/conf/application.conf
@@ -5,10 +5,6 @@ pekko {
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
 }
 
-// https://www.playframework.com/documentation/latest/SecurityHeaders
-// Disable the out of the box content security policy in SecurityHeadersFilter
-play.filters.headers.contentSecurityPolicy = null
-
 // https://www.playframework.com/documentation/latest/AllowedHostsFilter
 play.filters.hosts.allowed = ["localhost:9000", "localhost:19001"]
 

--- a/play-java-jpa-example/conf/META-INF/persistence.xml
+++ b/play-java-jpa-example/conf/META-INF/persistence.xml
@@ -7,7 +7,6 @@
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
       <property name="hibernate.hbm2ddl.auto" value="update"/>
     </properties>
   </persistence-unit>

--- a/play-java-rest-api-example/conf/META-INF/persistence.xml
+++ b/play-java-rest-api-example/conf/META-INF/persistence.xml
@@ -7,7 +7,6 @@
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
       <property name="hibernate.hbm2ddl.auto" value="update"/>
     </properties>
   </persistence-unit>

--- a/play-java-starter-example/conf/application.conf
+++ b/play-java-starter-example/conf/application.conf
@@ -258,9 +258,6 @@ play.filters {
 
     # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
     #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
   }
 
   ## Allowed hosts filter configuration

--- a/play-scala-chatroom-example/conf/application.conf
+++ b/play-scala-chatroom-example/conf/application.conf
@@ -5,10 +5,6 @@ pekko {
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
 }
 
-// https://www.playframework.com/documentation/latest/SecurityHeaders
-// Disable the out of the box content security policy in SecurityHeadersFilter
-play.filters.headers.contentSecurityPolicy = null
-
 // https://www.playframework.com/documentation/latest/AllowedHostsFilter
 play.filters.hosts.allowed = ["localhost:9000", "localhost:19001"]
 

--- a/play-scala-log4j2-example/conf/application.conf
+++ b/play-scala-log4j2-example/conf/application.conf
@@ -254,9 +254,6 @@ play.filters {
 
     # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
     #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
   }
 
   ## Allowed hosts filter configuration

--- a/play-scala-starter-example/conf/application.conf
+++ b/play-scala-starter-example/conf/application.conf
@@ -258,9 +258,6 @@ play.filters {
 
     # The X-Permitted-Cross-Domain-Policies header. If null, the header is not set.
     #permittedCrossDomainPolicies = "master-only"
-
-    # The Content-Security-Policy header. If null, the header is not set.
-    #contentSecurityPolicy = "default-src 'self'"
   }
 
   ## Allowed hosts filter configuration

--- a/play-scala-streaming-example/conf/application.conf
+++ b/play-scala-streaming-example/conf/application.conf
@@ -4,7 +4,6 @@
 # Allow URLs from the same origin to be loaded by frames and scripts
 play.filters.headers {
   frameOptions = "SAMEORIGIN"
-  contentSecurityPolicy = "connect-src 'self'"
 }
 
 play.filters.enabled += play.filters.csp.CSPFilter

--- a/play-scala-websocket-example/conf/application.conf
+++ b/play-scala-websocket-example/conf/application.conf
@@ -13,11 +13,11 @@ pekko {
   }
 }
 
+play.filters.enabled += play.filters.csp.CSPFilter
 
-# https://www.playframework.com/documentation/latest/SecurityHeaders
-# Connect to localhost:9000 for content security policy on websockets
-play.filters.headers {
-  contentSecurityPolicy = "connect-src 'self' ws://localhost:9000"
+play.filters.csp.directives {
+  connect-src = "'self' ws://localhost:9000"
+  default-src = "'self'"
 }
 
 # https://www.playframework.com/documentation/latest/AllowedHostsFilter


### PR DESCRIPTION
See https://www.playframework.com/documentation/3.0.x/Migration27#play.filters.headers.contentSecurityPolicy-deprecated-for-CSPFilter