### PR TITLE
Dependabot should upgrade GitHub actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "3.0.x"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.9.x"


### PR DESCRIPTION
Almost the same like
- #564

but for the main branch, which currently isn't the default branch in this repo. Assuming this branch will become the default branch one day, I already add the file here so we have it in place (and also don't forget about it).