### PR TITLE
[3.0.x] Add prefix to Dependabot commit message / PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "[3.0.x] "
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -14,3 +16,5 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "2.9.x"
+    commit-message:
+      prefix: "[2.9.x] "


### PR DESCRIPTION
Similiar to
- #573

but #573 was against the `main` branch which currently is _not_ the default branch of this repo (#573 and the previous pr just prepared the main branch to become the default branch one day)