### PR TITLE
Pin bootstrap in scala steward config

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -6,6 +6,10 @@ pullRequests.grouping = [
   { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] }
 ]
 
+updates.pin = [
+  { groupId = "org.webjars", artifactId = "bootstrap", version = "3.4." }
+]
+
 buildRoots = [
   "play-java-pekko-cluster-example",
   "play-java-chatroom-example",


### PR DESCRIPTION
Upgrading bootstrap would require manual work. I think for sample it does not matter which bootstrap version is used as long as the sample works.