### PR TITLE
Fix `play-scala-websocket-example` (missing csp nonce)

### DIFF
--- a/play-scala-websocket-example/app/assets/javascripts/index.coffee
+++ b/play-scala-websocket-example/app/assets/javascripts/index.coffee
@@ -96,5 +96,5 @@ handleFlip = (container) ->
         detailsHolder.append($("<h2>").text("Error: " + JSON.parse(jqXHR.responseText).error))
     # display loading info
     detailsHolder = container.find(".details-holder")
-    detailsHolder.append($("<h4>").text("Determing whether you should buy or sell based on the sentiment of recent tweets..."))
+    detailsHolder.append($("<h4>").text("Determining whether you should buy or sell based on the sentiment of recent tweets..."))
     detailsHolder.append($("<div>").addClass("progress progress-striped active").append($("<div>").addClass("bar").css("width", "100%")))

--- a/play-scala-websocket-example/app/assets/stylesheets/main.less
+++ b/play-scala-websocket-example/app/assets/stylesheets/main.less
@@ -95,6 +95,7 @@ body {
   .transform(180deg);
   text-align: center;
   z-index: 1;
+  transform-style: preserve-3d;
   & h4 {
     padding: 20px;
   }

--- a/play-scala-websocket-example/app/views/index.scala.html
+++ b/play-scala-websocket-example/app/views/index.scala.html
@@ -5,7 +5,7 @@
 <head>
     <title>Reactive Stock News Dashboard</title>
     <link rel='stylesheet' href='@routes.Assets.at("lib/bootstrap/css/bootstrap.min.css")'>
-    <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+    <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.min.css")">
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
     <script @{CSPNonce.attr} type='text/javascript' src='@routes.Assets.at("lib/jquery/jquery.min.js")'></script>
     <script @{CSPNonce.attr} type='text/javascript' src='@routes.Assets.at("lib/flot/jquery.flot.js")'></script>

--- a/play-scala-websocket-example/app/views/index.scala.html
+++ b/play-scala-websocket-example/app/views/index.scala.html
@@ -7,9 +7,9 @@
     <link rel='stylesheet' href='@routes.Assets.at("lib/bootstrap/css/bootstrap.min.css")'>
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-    <script type='text/javascript' src='@routes.Assets.at("lib/jquery/jquery.min.js")'></script>
-    <script type='text/javascript' src='@routes.Assets.at("lib/flot/jquery.flot.js")'></script>
-    <script type='text/javascript' src='@routes.Assets.at("javascripts/index.js")'></script>
+    <script @{CSPNonce.attr} type='text/javascript' src='@routes.Assets.at("lib/jquery/jquery.min.js")'></script>
+    <script @{CSPNonce.attr} type='text/javascript' src='@routes.Assets.at("lib/flot/jquery.flot.js")'></script>
+    <script @{CSPNonce.attr} type='text/javascript' src='@routes.Assets.at("javascripts/index.js")'></script>
 </head>
 <body data-ws-url="@routes.HomeController.ws.webSocketURL()">
     <div class="navbar navbar-inverse navbar-fixed-top">

--- a/play-scala-websocket-example/build.sbt
+++ b/play-scala-websocket-example/build.sbt
@@ -1,5 +1,3 @@
-import play.core.PlayVersion.pekkoVersion
-
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
   //.enablePlugins(PlayNettyServer).disablePlugins(PlayPekkoHttpServer) // uncomment to use the Netty backend
@@ -19,6 +17,7 @@ lazy val root = (project in file("."))
     TwirlKeys.templateImports ++= Seq(
       "views.html.helper.CSPNonce"
     ),
+    LessKeys.compress := true,
     (Test / javaOptions) += "-Dtestserver.port=19001",
     scalacOptions ++= Seq(
       "-feature",

--- a/play-scala-websocket-example/build.sbt
+++ b/play-scala-websocket-example/build.sbt
@@ -16,6 +16,9 @@ lazy val root = (project in file("."))
       "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test,
       "org.awaitility" % "awaitility" % "4.2.1" % Test,
     ),
+    TwirlKeys.templateImports ++= Seq(
+      "views.html.helper.CSPNonce"
+    ),
     (Test / javaOptions) += "-Dtestserver.port=19001",
     scalacOptions ++= Seq(
       "-feature",

--- a/play-scala-websocket-example/conf/application.conf
+++ b/play-scala-websocket-example/conf/application.conf
@@ -1,22 +1,24 @@
+# This is the main configuration file for the application.
+# ~~~~~
+
 # Uncomment this for the most verbose Pekko debugging:
 pekko {
   loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
-  loglevel = "DEBUG"
+  loglevel = "INFO"
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
-
-  actor {
-    debug {
-      #receive = on
-      #autoreceive = on
-      #lifecycle = on
-    }
-  }
+  #actor {
+  #  debug {
+  #    receive = on
+  #    autoreceive = on
+  #    lifecycle = on
+  #  }
+  #}
 }
 
 play.filters.enabled += play.filters.csp.CSPFilter
 
 play.filters.csp.directives {
-  connect-src = "'self' ws://localhost:9000"
+  connect-src = "'self'"
   default-src = "'self'"
 }
 

--- a/play-scala-websocket-example/conf/logback.xml
+++ b/play-scala-websocket-example/conf/logback.xml
@@ -25,11 +25,12 @@
   <logger name="play" level="INFO"/>
 
   <!-- actors logging -->
-  <logger name="org.apache.pekko" level="DEBUG"/>
+  <logger name="org.apache.pekko" level="INFO"/>
+  <logger name="org.apache.pekko.stream.Log" level="INFO"/>
   <logger name="actors" level="DEBUG"/>
 
   <!-- controllers -->
-  <logger name="controllers" level="DEBUG"/>
+  <logger name="controllers" level="INFO"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT"/>

--- a/play-scala-websocket-example/project/plugins.sbt
+++ b/play-scala-websocket-example/project/plugins.sbt
@@ -1,4 +1,3 @@
-// Use the Play sbt plugin for Play projects
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-less" % "2.0.1")

--- a/play-scala-websocket-example/test/controllers/WebSocketClient.java
+++ b/play-scala-websocket-example/test/controllers/WebSocketClient.java
@@ -8,6 +8,7 @@ import play.shaded.ahc.org.asynchttpclient.ws.WebSocket;
 import play.shaded.ahc.org.asynchttpclient.ws.WebSocketListener;
 
 import play.shaded.ahc.org.asynchttpclient.ws.WebSocketUpgradeHandler;
+import org.slf4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -29,7 +30,7 @@ public class WebSocketClient {
         final BoundRequestBuilder requestBuilder = client.prepareGet(url).addHeader("Origin", origin);
 
         final WebSocketUpgradeHandler handler = new WebSocketUpgradeHandler.Builder().addWebSocketListener(listener).build();
-        ListenableFuture<NettyWebSocket> future = requestBuilder.execute(handler);
+        final ListenableFuture<NettyWebSocket> future = requestBuilder.execute(handler);
         return future.toCompletableFuture();
     }
 
@@ -39,6 +40,8 @@ public class WebSocketClient {
         public LoggingListener(Consumer<String> onMessageCallback) {
             this.onMessageCallback = onMessageCallback;
         }
+
+        private Logger logger = org.slf4j.LoggerFactory.getLogger(LoggingListener.class);
 
         private Throwable throwableFound = null;
 
@@ -62,6 +65,7 @@ public class WebSocketClient {
 
         @Override
         public void onTextFrame(String payload, boolean finalFragment, int rsv) {
+            //logger.info("onMessage: s = " + s);
             onMessageCallback.accept(payload);
         }
     }


### PR DESCRIPTION
- Alternative for #667

The example is not working because the js files can not be loaded because they violate the csp directives.
Play's default `script-src`  directive is [this one](https://github.com/playframework/playframework/blob/3.0.4/web/play-filters-helpers/src/main/resources/reference.conf#L210):
```
      # script-src defaults according to https://csp.withgoogle.com/docs/strict-csp.html
      # https://www.w3.org/TR/CSP3/#directive-script-src
      script-src = ${play.filters.csp.nonce.pattern} "'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"
```

So for this example this will be rendered to following header:
```
Content-Security-Policy: base-uri 'none'; script-src 'nonce-1BANcXNZ6pGIEXrrAszpvw==' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; default-src 'self'; object-src 'none'; connect-src 'self' ws://localhost:9000
```

So all we need to do is to add the nonce to the js files so they are allowed to load.
It's basically the same we fixed #662 with.