### PR TITLE
Revert "Configure Dependabot for Gradle"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "gradle"
-    directories:
-      - "java/*"
-      - "scala/*"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This reverts commit 5967cd960441355d0594573509fd58da3dda79dd.
In favor of #696 