### PR TITLE
[Gradle] Use ScalaTest + JUnit 5

### DIFF
--- a/scala/chatroom/build.gradle
+++ b/scala/chatroom/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation libs.logstash.logback.encoder
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/chatroom/gradle/libs.versions.toml
+++ b/scala/chatroom/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ webjars-play = "3.0.1"
 jsoup = "1.17.2"
 flot = "0.8.3-1"
 bootstrap = "3.3.7-1"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
@@ -12,7 +13,7 @@ jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 flot = { group = "org.webjars", name = "flot", version.ref = "flot" }
 bootstrap = { group = "org.webjars", name = "bootstrap", version.ref = "bootstrap" }
 logstash-logback-encoder = { group = "net.logstash.logback", name = "logstash-logback-encoder", version = "7.3" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/compile-di/build.gradle
+++ b/scala/compile-di/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/compile-di/gradle/libs.versions.toml
+++ b/scala/compile-di/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/fileupload/build.gradle
+++ b/scala/fileupload/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/fileupload/gradle/libs.versions.toml
+++ b/scala/fileupload/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/forms/build.gradle
+++ b/scala/forms/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/forms/gradle/libs.versions.toml
+++ b/scala/forms/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/hello-world/build.gradle
+++ b/scala/hello-world/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/hello-world/gradle/libs.versions.toml
+++ b/scala/hello-world/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/log4j2/build.gradle
+++ b/scala/log4j2/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation libs.log4j.core
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/log4j2/gradle/libs.versions.toml
+++ b/scala/log4j2/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 log4j = "2.23.1"
 
@@ -8,7 +9,7 @@ log4j = "2.23.1"
 log4j-slf4j-impl = { group = "org.apache.logging.log4j", name = "log4j-slf4j-impl", version.ref = "log4j" }
 log4j-api = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
 log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version.ref = "log4j" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/macwire-di/build.gradle
+++ b/scala/macwire-di/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly "com.softwaremill.macwire:macros_${scalaVersion}:${libs.versions.macwire.get()}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/macwire-di/gradle/libs.versions.toml
+++ b/scala/macwire-di/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 macwire = "2.5.9"
 
 [libraries]
 macwire = { group = "com.softwaremill.macwire", name = "macros_2.13", version.ref = "macwire" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/rest-api/build.gradle
+++ b/scala/rest-api/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     testImplementation "org.playframework:play-test_${scalaVersion}"
     testImplementation "org.playframework:play-filters-helpers_${scalaVersion}"
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/rest-api/gradle/libs.versions.toml
+++ b/scala/rest-api/gradle/libs.versions.toml
@@ -3,13 +3,14 @@ twirl = "2.0.6"
 play = "3.0.2-773ecf9b-SNAPSHOT"
 scala-guice = "6.0.0"
 scala-uri = "4.0.3"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
 logstash-logback-encoder = { group = "net.logstash.logback", name = "logstash-logback-encoder", version = "7.3" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
 scala-guice = { group = "net.codingwell", name = "scala-guice_2.13", version.ref = "scala-guice" }
 scala-uri = { group = "io.lemonlabs", name = "scala-uri_2.13", version.ref = "scala-uri" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 [plugins]

--- a/scala/secure-session/build.gradle
+++ b/scala/secure-session/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation "org.apache.pekko:pekko-cluster-typed_${scalaVersion}:${libs.versions.pekko.get()}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/secure-session/gradle/libs.versions.toml
+++ b/scala/secure-session/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 pekko = "1.0.2"
 
@@ -8,7 +9,7 @@ pekko = "1.0.2"
 kalium = { group = "org.abstractj.kalium", name = "kalium", version = "0.8.0" }
 jnr-ffi = { group = "com.github.jnr", name = "jnr-ffi", version = "2.2.16" }
 pekko-distributed-data = { group = "org.apache.pekko", name = "pekko-distributed-data_2.13", version.ref = "pekko" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/starter/build.gradle
+++ b/scala/starter/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/starter/gradle/libs.versions.toml
+++ b/scala/starter/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.1-03969c1e-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/streaming/build.gradle
+++ b/scala/streaming/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation "org.playframework:play-logback_${scalaVersion}"
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 run {

--- a/scala/streaming/gradle/libs.versions.toml
+++ b/scala/streaming/gradle/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
 twirl = "2.0.6"
 play = "3.0.2-773ecf9b-SNAPSHOT"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 
 [libraries]
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 
 

--- a/scala/websocket/build.gradle
+++ b/scala/websocket/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     testImplementation "org.scalatestplus.play:scalatestplus-play_${scalaVersion}:${libs.versions.scalatestplus.play.get()}"
     testImplementation libs.awaitility
-    testImplementation libs.scalatest.junit.runner
+    testRuntimeOnly "org.scalatestplus:junit-5-10_${scalaVersion}:${libs.versions.scalatestplus.asProvider().get()}"
 }
 
 sourceSets {

--- a/scala/websocket/gradle/libs.versions.toml
+++ b/scala/websocket/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 twirl = "2.0.6"
 play = "3.0.2-773ecf9b-SNAPSHOT"
 play-ws = "3.0.0"
+scalatestplus = "3.2.19.0"
 scalatestplus-play = "7.0.1"
 flot = "0.8.3-1"
 bootstrap = "3.4.1"
@@ -12,7 +13,7 @@ node = "7.0.1"
 [libraries]
 flot = { group = "org.webjars", name = "flot", version.ref = "flot" }
 bootstrap = { group = "org.webjars", name = "bootstrap", version.ref = "bootstrap" }
-scalatest-junit-runner = { group = "co.helmethair", name = "scalatest-junit-runner", version = "0.1.12" }
+scalatest-junit5 = { group = "org.scalatestplus", name = "junit-5-10_2.13", version.ref = "scalatestplus" }
 scalatestplus-play = { group = "org.scalatestplus.play", name = "scalatestplus-play_2.13", version.ref = "scalatestplus-play" }
 awaitility = { group = "org.awaitility", name = "awaitility", version.ref = "awaitility" }
 


### PR DESCRIPTION
We don't need to use `scalatest-junit-runner` anymore.
ScalaTest has native support now https://www.scalatest.org/plus/junit5