### PR TITLE
[3.0.x] Upgrade flyway-sbt + flyway-core to 10.21.0

### DIFF
--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -6,7 +6,7 @@ lazy val databaseUrl = sys.env.getOrElse("DB_DEFAULT_URL", "jdbc:h2:./test")
 lazy val databaseUser = sys.env.getOrElse("DB_DEFAULT_USER", "sa")
 lazy val databasePassword = sys.env.getOrElse("DB_DEFAULT_PASSWORD", "")
 
-val FlywayVersion = "9.21.1"
+val FlywayVersion = "9.22.0"
 
 (ThisBuild / version) := "1.1-SNAPSHOT"
 
@@ -30,7 +30,11 @@ val FlywayVersion = "9.21.1"
 lazy val flyway = (project in file("modules/flyway"))
   .enablePlugins(FlywayPlugin)
   .settings(
-    libraryDependencies += "org.flywaydb" % "flyway-core" % FlywayVersion,
+    libraryDependencies += ("org.flywaydb" % "flyway-core" % FlywayVersion).excludeAll(
+      ExclusionRule("com.fasterxml.jackson.core"),
+      ExclusionRule("com.fasterxml.jackson.dataformat"),
+      ExclusionRule("com.fasterxml.jackson.datatype")
+    ),
     flywayLocations := Seq("classpath:db/migration"),
     flywayUrl := databaseUrl,
     flywayUser := databaseUser,
@@ -84,11 +88,13 @@ lazy val root = (project in file("."))
     TwirlKeys.templateImports += "com.example.user.User",
     libraryDependencies ++= Seq(
       guice,
-      "com.h2database" % "h2" % "1.4.200", // Can't use latest h2 currently: flyway-sbt comes with an outdated flyway version that does not support h2 2.x yet...:
-      // https://github.com/flyway/flyway-sbt/blob/7fc35d2833531b2b9e5a98a594d76fd047a077a8/build.sbt#L1
-      // https://github.com/flyway/flyway-sbt/issues/82#issuecomment-1636728997
+      "com.h2database" % "h2" % "2.3.232",
       ws % Test,
-      "org.flywaydb" % "flyway-core" % FlywayVersion % Test,
+      ("org.flywaydb" % "flyway-core" % FlywayVersion % Test).excludeAll(
+        ExclusionRule("com.fasterxml.jackson.core"),
+        ExclusionRule("com.fasterxml.jackson.dataformat"),
+        ExclusionRule("com.fasterxml.jackson.datatype")
+      ),
       "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
     ),
     (Test / fork) := true

--- a/play-scala-isolated-slick-example/build.sbt
+++ b/play-scala-isolated-slick-example/build.sbt
@@ -6,7 +6,7 @@ lazy val databaseUrl = sys.env.getOrElse("DB_DEFAULT_URL", "jdbc:h2:./test")
 lazy val databaseUser = sys.env.getOrElse("DB_DEFAULT_USER", "sa")
 lazy val databasePassword = sys.env.getOrElse("DB_DEFAULT_PASSWORD", "")
 
-val FlywayVersion = "9.22.0"
+val FlywayVersion = "10.21.0"
 
 (ThisBuild / version) := "1.1-SNAPSHOT"
 

--- a/play-scala-isolated-slick-example/project/plugins.sbt
+++ b/play-scala-isolated-slick-example/project/plugins.sbt
@@ -2,7 +2,7 @@ libraryDependencies += "com.h2database" % "h2" % "2.3.232"
 
 // Database migration
 // https://github.com/flyway/flyway-sbt
-addSbtPlugin("com.github.sbt" % "flyway-sbt" % "9.22.0")
+addSbtPlugin("com.github.sbt" % "flyway-sbt" % "10.21.0")
 
 // Slick code generation
 // https://github.com/tototoshi/sbt-slick-codegen

--- a/play-scala-isolated-slick-example/project/plugins.sbt
+++ b/play-scala-isolated-slick-example/project/plugins.sbt
@@ -1,8 +1,8 @@
-libraryDependencies += "com.h2database" % "h2" % "1.4.200" // Can't use latest h2 currently: https://github.com/flyway/flyway-sbt/issues/82#issuecomment-1636728997
+libraryDependencies += "com.h2database" % "h2" % "2.3.232"
 
 // Database migration
 // https://github.com/flyway/flyway-sbt
-addSbtPlugin("io.github.davidmweber" % "flyway-sbt" % "7.4.0")
+addSbtPlugin("com.github.sbt" % "flyway-sbt" % "9.22.0")
 
 // Slick code generation
 // https://github.com/tototoshi/sbt-slick-codegen


### PR DESCRIPTION
https://github.com/sbt/flyway-sbt/releases/tag/v10.21.0

We can now revert
- #523
- #366

Also, flyway 9.21.2 [upgraded jackson to 2.15.2](https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html#ReleaseNotesforFlywayEngine-Flyway9.21.2(2023-08-22)), so we exclude that from flyway's dependencies to avoid running into an exception regarding `jackson-module-scala` incompabitle (2.14 play comes with vs 2.15)