### PR TITLE
Check Netty backend for Gradle examples

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -75,8 +75,6 @@ jobs:
       gradle-build-root: java/chatroom
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/chatroom --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -91,8 +89,6 @@ jobs:
       gradle-build-root: java/compile-di
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/compile-di --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -107,8 +103,6 @@ jobs:
       gradle-build-root: java/dagger2
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/dagger2 --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -123,8 +117,6 @@ jobs:
       gradle-build-root: java/ebean
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/ebean --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
         
@@ -139,8 +131,6 @@ jobs:
       gradle-build-root: java/fileupload
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/fileupload --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
         
@@ -155,8 +145,6 @@ jobs:
       gradle-build-root: java/forms
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/forms --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -186,8 +174,6 @@ jobs:
       gradle-build-root: java/hello-world
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/hello-world --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -202,8 +188,6 @@ jobs:
       gradle-build-root: java/jpa
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/jpa --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -218,8 +202,6 @@ jobs:
       gradle-build-root: java/pekko-cluster
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/pekko-cluster --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -234,8 +216,6 @@ jobs:
       gradle-build-root: java/rest-api
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/rest-api --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -250,8 +230,6 @@ jobs:
       gradle-build-root: java/starter
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/starter --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -266,8 +244,6 @@ jobs:
       gradle-build-root: java/streaming
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/streaming --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -282,8 +258,6 @@ jobs:
       gradle-build-root: java/websocket
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=java/websocket --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 
@@ -439,8 +413,6 @@ jobs:
       gradle-build-root: scala/rest-api
       add-dimensions: >-
         { "server": [ "pekko", "netty"], "build_tool": ["sbt", "gradle"] }
-      exclude: >-
-        [{ "server": "netty", "build_tool": "gradle" }]
       cmd: |
         ./test.sh --sample=scala/rest-api --backend-server=$MATRIX_SERVER --build-tool=$MATRIX_BUILD_TOOL
 

--- a/java/chatroom/build.gradle.kts
+++ b/java/chatroom/build.gradle.kts
@@ -6,12 +6,13 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
     implementation("org.playframework:play-java-forms_$scalaVersion")
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-ahc-ws_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")

--- a/java/compile-di/build.gradle.kts
+++ b/java/compile-di/build.gradle.kts
@@ -5,12 +5,13 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
     implementation("org.playframework:play-java_$scalaVersion")
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-filters-helpers_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")
 

--- a/java/dagger2/build.gradle.kts
+++ b/java/dagger2/build.gradle.kts
@@ -7,11 +7,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-ahc-ws_$scalaVersion")
     implementation("org.playframework:play-filters-helpers_$scalaVersion")

--- a/java/ebean/build.gradle.kts
+++ b/java/ebean/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.asProvider().get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-jdbc_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")

--- a/java/fileupload/build.gradle.kts
+++ b/java/fileupload/build.gradle.kts
@@ -7,11 +7,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-filters-helpers_$scalaVersion")

--- a/java/forms/build.gradle.kts
+++ b/java/forms/build.gradle.kts
@@ -7,11 +7,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-filters-helpers_$scalaVersion")

--- a/java/hello-world/build.gradle.kts
+++ b/java/hello-world/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")

--- a/java/jpa/build.gradle.kts
+++ b/java/jpa/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.asProvider().get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-java-jpa_$scalaVersion")

--- a/java/pekko-cluster/build.gradle.kts
+++ b/java/pekko-cluster/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")

--- a/java/rest-api/build.gradle.kts
+++ b/java/rest-api/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-java-jpa_$scalaVersion")

--- a/java/starter/build.gradle.kts
+++ b/java/starter/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")

--- a/java/streaming/build.gradle.kts
+++ b/java/streaming/build.gradle.kts
@@ -6,11 +6,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-logback_$scalaVersion")

--- a/java/websocket/build.gradle.kts
+++ b/java/websocket/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
 }
 
 val scalaVersion = System.getProperty("scala.version", PlayPlugin.DEFAULT_SCALA_VERSION).trimEnd { !it.isDigit() }
+val server = System.getProperty("backend.server", "netty").let { if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation(platform("org.playframework:play-bom_$scalaVersion:${libs.versions.play.asProvider().get()}"))
 
-    implementation("org.playframework:play-pekko-http-server_$scalaVersion")
+    implementation("org.playframework:play-$server-server_$scalaVersion")
     implementation("org.playframework:play-guice_$scalaVersion")
     implementation("org.playframework:play-java-forms_$scalaVersion")
     implementation("org.playframework:play-filters-helpers_$scalaVersion")

--- a/scala/chatroom/build.gradle
+++ b/scala/chatroom/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"
     implementation "org.webjars:webjars-play_$scalaVersion:${libs.versions.webjars.play.get()}"

--- a/scala/compile-di/build.gradle
+++ b/scala/compile-di/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/fileupload/build.gradle
+++ b/scala/fileupload/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/forms/build.gradle
+++ b/scala/forms/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/hello-world/build.gradle
+++ b/scala/hello-world/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"
 

--- a/scala/log4j2/build.gradle
+++ b/scala/log4j2/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation libs.log4j.slf4j.impl
     implementation libs.log4j.api

--- a/scala/macwire-di/build.gradle
+++ b/scala/macwire-di/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/rest-api/build.gradle
+++ b/scala/rest-api/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"
     implementation "net.codingwell:scala-guice_${scalaVersion}:${libs.versions.scala.guice.get()}"

--- a/scala/secure-session/build.gradle
+++ b/scala/secure-session/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/starter/build.gradle
+++ b/scala/starter/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"
 

--- a/scala/streaming/build.gradle
+++ b/scala/streaming/build.gradle
@@ -11,11 +11,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/scala/websocket/build.gradle
+++ b/scala/websocket/build.gradle
@@ -12,11 +12,12 @@ play {
 }
 
 def scalaVersion = System.getProperty('scala.version', PlayPlugin.DEFAULT_SCALA_VERSION).replaceAll('\\D*$', '')
+def server = System.getProperty('backend.server', 'pekko-http').with {if (it == "pekko") "pekko-http" else it }
 
 dependencies {
     implementation platform("org.playframework:play-bom_${scalaVersion}:${libs.versions.play.asProvider().get()}")
 
-    implementation "org.playframework:play-pekko-http-server_${scalaVersion}"
+    implementation "org.playframework:play-${server}-server_${scalaVersion}"
     implementation "org.playframework:play-guice_${scalaVersion}"
     implementation "org.playframework:play-filters-helpers_${scalaVersion}"
     implementation "org.playframework:play-logback_${scalaVersion}"

--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ fi
 
 # Initialize variables
 sample=""
-backend_server="pekko"
+backend_server="pekko-http"
 build_tool="sbt"
 
 # Parse command line arguments
@@ -37,7 +37,7 @@ function buildSample() {
         echo "+-------------------------------+"
         echo "| Executing tests using Gradle  |"
         echo "+-------------------------------+"
-        ./gradlew -Dscala.version="$MATRIX_SCALA" check
+        ./gradlew -Dscala.version="$MATRIX_SCALA" -Dbackend.server="$backend_server" clean check
       fi
     elif [[ $build_tool == "sbt" ]]; then
       if [[ $backend_server == "netty" ]]; then


### PR DESCRIPTION
@mkurz while you are reviewing my PRs to core repo I can do something useful for our samples 😄 

So, now we check a Netty backend for all Gradle samples.
Outside the CI Netty is default for Java examples, Pekko for Scala.
