### PR TITLE
Fix play-scala-isolated-slick-example test for Scala 3

### DIFF
--- a/play-scala-isolated-slick-example/app/models/UserRequest.scala
+++ b/play-scala-isolated-slick-example/app/models/UserRequest.scala
@@ -18,6 +18,6 @@ object UserRequest {
     mapping(
       "id" -> optional(nonEmptyText),
       "email" -> email
-    )(UserRequest.apply)(UserRequest.unapply)
+    )(UserRequest.apply)(u => Some((u.id, u.email)))
   )
 }

--- a/play-scala-isolated-slick-example/scripts/test-sbt
+++ b/play-scala-isolated-slick-example/scripts/test-sbt
@@ -4,4 +4,4 @@ echo "+----------------------------+"
 echo "| Executing tests using sbt  |"
 echo "+----------------------------+"
 rm -f test.mv.db test.trace.db
-sbt ++$MATRIX_SCALA clean reload flyway/flywayMigrate slickCodegen test
+sbt ++$MATRIX_SCALA clean reload ++$MATRIX_SCALA flyway/flywayMigrate slickCodegen test


### PR DESCRIPTION
After the `reload` the Scala version gets set back to the default again.
So when running tests for Scala 3, having `MATRIX_SCALA=3.x` after the reload we are on Scala 2.13.x again...

I found this because I wanted to test Scala 3.3.7-RC2 locally and only published Play for that Scala 3 version and this test complained it can not find the 2.13.x artifacts... 