### PR TITLE
Add `run-sbt-command`, can be used as `sbt` drop-in but runs both sbt 1 and 2

### DIFF
--- a/java/rest-api/scripts/test-sbt
+++ b/java/rest-api/scripts/test-sbt
@@ -3,10 +3,10 @@
 set -e
 set -o pipefail
 
-echo "+----------------------------+"
-echo "| Executing tests using sbt  |" 
-echo "+----------------------------+"
-sbt ++$MATRIX_SCALA test
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
+"$repo_root/run-sbt-command" "++$MATRIX_SCALA" test
 
 # At least verifies that Gatling tests are compiling
-sbt ++$MATRIX_SCALA ";project gatling; gatling:compile"
+"$repo_root/run-sbt-command" "++$MATRIX_SCALA" ";project gatling; gatling:compile"

--- a/run-sbt-command
+++ b/run-sbt-command
@@ -2,10 +2,35 @@
 
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sample_path="$(pwd)"
+sample_path="${sample_path#$repo_root/}"
+
 sbt_bin="${SBT_BIN:-sbt}"
 run_sbt1="${RUN_SBT1_TESTS:-true}"
 sbt2_version="${MATRIX_SBT2:-2.0.0-RC11}"
 run_sbt2="${RUN_SBT2_TESTS:-true}"
+
+sbt2_blacklist=(
+    # https://github.com/gatling/gatling-sbt-plugin not published for sbt 2
+    "scala/rest-api"
+    "java/rest-api"
+     # https://github.com/tototoshi/sbt-slick-codegen/pull/103
+     "scala/isolated-slick"
+     # https://github.com/apache/pekko-grpc/issues/677
+     "scala/grpc"
+     "java/grpc"
+     # needs a fix in Play itself
+     "java/jpa"
+)
+
+skip_sbt2="false"
+for blacklisted_sample in "${sbt2_blacklist[@]}"; do
+    if [[ "$sample_path" == "$blacklisted_sample" ]]; then
+        skip_sbt2="true"
+        break
+    fi
+done
 
 if [ "$#" -eq 0 ]; then
     echo "Usage: $0 <sbt-args...>"
@@ -19,9 +44,11 @@ if [[ "$run_sbt1" == "true" ]]; then
     "$sbt_bin" "$@"
 fi
 
-if [[ "$run_sbt2" == "true" ]]; then
+if [[ "$run_sbt2" == "true" && "$skip_sbt2" != "true" ]]; then
     echo "+--------------------------------------+"
     echo "| Executing tests using sbt $sbt2_version |"
     echo "+--------------------------------------+"
     "$sbt_bin" -Dsbt.version="$sbt2_version" "$@"
+elif [[ "$run_sbt2" == "true" && "$skip_sbt2" == "true" ]]; then
+    echo "Skipping sbt $sbt2_version for blacklisted sample: $sample_path"
 fi

--- a/run-sbt-command
+++ b/run-sbt-command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sbt_bin="${SBT_BIN:-sbt}"
+sbt2_version="${MATRIX_SBT2:-2.0.0-RC11}"
+run_sbt2="${RUN_SBT2_TESTS:-true}"
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <sbt-args...>"
+    exit 1
+fi
+
+echo "+-----------------------------+"
+echo "| Executing tests using sbt 1 |"
+echo "+-----------------------------+"
+"$sbt_bin" "$@"
+
+if [[ "$run_sbt2" == "true" ]]; then
+    echo "+--------------------------------------+"
+    echo "| Executing tests using sbt $sbt2_version |"
+    echo "+--------------------------------------+"
+    "$sbt_bin" -Dsbt.version="$sbt2_version" "$@"
+fi

--- a/run-sbt-command
+++ b/run-sbt-command
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 sbt_bin="${SBT_BIN:-sbt}"
+run_sbt1="${RUN_SBT1_TESTS:-true}"
 sbt2_version="${MATRIX_SBT2:-2.0.0-RC11}"
 run_sbt2="${RUN_SBT2_TESTS:-true}"
 
@@ -11,10 +12,12 @@ if [ "$#" -eq 0 ]; then
     exit 1
 fi
 
-echo "+-----------------------------+"
-echo "| Executing tests using sbt 1 |"
-echo "+-----------------------------+"
-"$sbt_bin" "$@"
+if [[ "$run_sbt1" == "true" ]]; then
+    echo "+-----------------------------+"
+    echo "| Executing tests using sbt 1 |"
+    echo "+-----------------------------+"
+    "$sbt_bin" "$@"
+fi
 
 if [[ "$run_sbt2" == "true" ]]; then
     echo "+--------------------------------------+"

--- a/scala/isolated-slick/scripts/test-sbt
+++ b/scala/isolated-slick/scripts/test-sbt
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-echo "+----------------------------+"
-echo "| Executing tests using sbt  |"
-echo "+----------------------------+"
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
 rm -f test.mv.db test.trace.db
-sbt ++$MATRIX_SCALA clean reload ++$MATRIX_SCALA flyway/flywayMigrate slickCodegen test
+"$repo_root/run-sbt-command" "++$MATRIX_SCALA" clean reload "++$MATRIX_SCALA" flyway/flywayMigrate slickCodegen test

--- a/scala/rest-api/scripts/test-sbt
+++ b/scala/rest-api/scripts/test-sbt
@@ -3,11 +3,11 @@
 set -e
 set -o pipefail
 
-echo "+----------------------------+"
-echo "| Executing tests using sbt  |"
-echo "+----------------------------+"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+
 # Do not run docs/paradox currently because sbt-paradox has not upgraded to sbt-web 1.6 yet:
 # https://github.com/lightbend/paradox/blob/v0.10.7/plugin/src/main/scala/com/lightbend/paradox/sbt/ParadoxPlugin.scala#L184
 # https://github.com/sbt/sbt-web/compare/1.5.8...1.6.0-M1#diff-ce81a99bce20c028fa631b7945b8317c5f614566c0df9ebadd3b3964e9e47817R589
-sbt ++$MATRIX_SCALA test # docs/paradox
-sbt ++$MATRIX_SCALA ";project gatling;gatling:compile"
+"$repo_root/run-sbt-command" "++$MATRIX_SCALA" test # docs/paradox
+"$repo_root/run-sbt-command" "++$MATRIX_SCALA" ";project gatling;gatling:compile"

--- a/scala/tls/conf/application.conf
+++ b/scala/tls/conf/application.conf
@@ -9,5 +9,5 @@ play.server.https.engineProvider=https.CustomSSLEngineProvider
 play.server.https.port = 9443
 
 // Allow example.com and subdomains
-play.filters.hosts.allowed = [".example.com"]
+play.filters.hosts.allowed = [".example.com", "localhost", "127.0.0.1"]
 

--- a/scala/tls/play
+++ b/scala/tls/play
@@ -1,13 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Export the keystore password for use in ws.conf
 export KEY_PASSWORD=`cat scripts/password`
 
+launcher_args=()
+while [[ $# -gt 0 && "$1" == -D* ]]; do
+  launcher_args+=("$1")
+  shift
+done
+
 # Turn on HTTPS, turn off HTTP.
 # This should be https://example.com:9443
-JVM_OPTIONS="$JVM_OPTIONS -Dhttp.port=disabled"
+JVM_OPTIONS="${JVM_OPTIONS:-} -Dhttp.port=disabled"
 JVM_OPTIONS="$JVM_OPTIONS -Dhttps.port=9443"
 
 # Note that using the HTTPS port by itself doesn't set rh.secure=true.
@@ -60,4 +68,4 @@ JVM_OPTIONS="$JVM_OPTIONS -Dtestserver.httpsport=19001"
 #export SBT_OPTS="$SBT_OPTS -Djavax.net.debug=all"
 
 # Run Play
-sbt $JVM_OPTIONS $*;
+sbt "${launcher_args[@]}" $JVM_OPTIONS "$@"

--- a/scala/tls/scripts/test-sbt
+++ b/scala/tls/scripts/test-sbt
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 export KEY_PASSWORD=`cat scripts/password` 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
 
-echo "+---------------------------------------+"
-echo "| Executing tests using (modified sbt)  |"
-echo "+---------------------------------------+"
-./play ++$MATRIX_SCALA test
+SBT_BIN=./play "$repo_root/run-sbt-command" "++$MATRIX_SCALA" test

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,8 @@
 #             rather than returning the exit status of the last command in the pipeline.
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ -z "$MATRIX_SCALA" ]; then
     echo "Error: the environment variable MATRIX_SCALA is not set"
     exit 1
@@ -46,10 +48,7 @@ function buildSample() {
       if [ -f scripts/test-sbt ]; then
         scripts/test-sbt
       else
-        echo "+----------------------------+"
-        echo "| Executing tests using sbt  |"
-        echo "+----------------------------+"
-        sbt ++$MATRIX_SCALA test
+        "$repo_root/run-sbt-command" "++$MATRIX_SCALA" test
       fi
     fi
     popd


### PR DESCRIPTION
- Next time tests run they run both on sbt 1 and sbt 2
- I added a blacklists for samples that do not work on sbt 2 (because some libraries are not yet published for sbt 2)

Tested locally.