### PR TITLE
Make rest of samples work with sbt 2

### DIFF
--- a/run-sbt-command
+++ b/run-sbt-command
@@ -12,14 +12,6 @@ sbt2_version="${MATRIX_SBT2:-2.0.0-RC11}"
 run_sbt2="${RUN_SBT2_TESTS:-true}"
 
 sbt2_blacklist=(
-    # https://github.com/gatling/gatling-sbt-plugin not published for sbt 2
-    "scala/rest-api"
-    "java/rest-api"
-     # https://github.com/tototoshi/sbt-slick-codegen/pull/103
-     "scala/isolated-slick"
-     # https://github.com/apache/pekko-grpc/issues/677
-     "scala/grpc"
-     "java/grpc"
 )
 
 skip_sbt2="false"


### PR DESCRIPTION
This is just a reminder to remove items from the sbt 2 blacklist.
- [ ] Waiting for sbt 2 support for https://github.com/gatling/gatling-sbt-plugin (I willl open a PR when I find time)
- [ ] https://github.com/tototoshi/sbt-slick-codegen/pull/103
- [x] https://github.com/apache/pekko-grpc/issues/677

Actually in the code comment I forgot `scala/rest-api` and both `*/grpc` samples also require `sbt-paradox` published for sbt 2:
- [x] https://github.com/lightbend/paradox/pull/678 