### PR TITLE
[2.9.x] Pin sbt-paradox

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -30,6 +30,7 @@ updates.pin = [
   { groupId = "com.typesafe.play", artifactId = "play-ebean", version = "7." },
   { groupId = "org.scalatestplus.play", artifactId = "scalatestplus-play", version = "6." },
   { groupId = "net.logstash.logback", artifactId = "logstash-logback-encoder", version = "7.3." },
+  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.10." },
   { groupId = "org.webjars", artifactId = "bootstrap", version = "3.4." },
   { groupId = "com.google.inject", artifactId = "guice", version = "6.0." },
   { groupId = "net.codingwell", artifactId = "scala-guice", version = "6.0." },


### PR DESCRIPTION
- #1395
  - parboiled needs java 17

````
[error] (docs / Compile / paradoxProcessor) java.lang.UnsupportedClassVersionError: org/pegdown/ParserWithDirectives has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```